### PR TITLE
Fix parse date for empty language

### DIFF
--- a/src/main/kotlin/com/bq/poeditor/gradle/utils/DateJsonAdapter.kt
+++ b/src/main/kotlin/com/bq/poeditor/gradle/utils/DateJsonAdapter.kt
@@ -20,6 +20,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import java.io.IOException
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -36,7 +37,11 @@ class DateJsonAdapter : JsonAdapter<Date>() {
     @Throws(IOException::class)
     override fun fromJson(reader: JsonReader): Date {
         val string = reader.nextString()
-        return sdf.parse(string)
+        return try {
+            sdf.parse(string)
+        } catch (e: ParseException) {
+            Date(0)
+        }
     }
 
     @Synchronized


### PR DESCRIPTION
### Github issue
Resolves #23 

### PR's key points
 
Languages with empty translations return empty updated data string from POEditor API which causes an error.