### PR TITLE
Add support for Android Gradle Plugin 4.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # Generated files
 .idea/**/contentModel.xml
+.idea/**/libraries-with-intellij-classes.xml
 
 # Sensitive or high-churn files
 .idea/**/dataSources/
@@ -129,5 +130,5 @@ gradle-app.setting
 # Output directory for tests
 /output
 
-# Donenv configuration file
+# Dotenv configuration file
 .env

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -34,7 +34,6 @@
       <option name="XML_KEEP_LINE_BREAKS" value="false" />
       <option name="XML_ALIGN_ATTRIBUTES" value="false" />
       <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <codeStyleSettings language="JAVA">
       <option name="METHOD_ANNOTATION_WRAP" value="1" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,11 @@ poEditor {
 }
 ```
 ### Changed
-- No changed features!
+- Add support for Android Gradle Plugin version 4.2.0
 ### Deprecated
 - No deprecated features!
 ### Removed
-- No removed features!
+- Remove support for Android Gradle Plugin versions lower than 4.2.0
 ### Fixed
 - No fixed issues!
 ### Security

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ repositories {
 dependencies {
     implementation(localGroovy())
 
-    compileOnly("com.android.tools.build:gradle:4.2.0-alpha01")
+    compileOnly("com.android.tools.build:gradle:4.2.0")
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.3.72")
 

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
@@ -18,6 +18,8 @@
 
 package com.hyperdevs.poeditor.gradle
 
+import com.android.build.api.extension.ApplicationAndroidComponentsExtension
+import com.android.build.api.extension.LibraryAndroidComponentsExtension
 import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.LibraryPlugin
@@ -83,16 +85,15 @@ class PoEditorPlugin : Plugin<Project> {
         // configurations with Android app modules.
         val configsExtensionContainer = project.container<PoEditorPluginExtension>()
         val androidExtension = project.the<BaseAppModuleExtension>()
+        val androidComponentsExtension = project.the<ApplicationAndroidComponentsExtension>()
         (androidExtension as ExtensionAware).extensions.add(POEDITOR_CONFIG_NAME, configsExtensionContainer)
 
         val configPoEditorTaskProvidersMap: MutableMap<ConfigName, TaskProvider<*>> = mutableMapOf()
 
         // Add tasks for every flavor or build type
-        androidExtension.onVariants {
-            // Add main extension since we have the main extension evaluated here
+        androidComponentsExtension.beforeVariants {
             addMainPoEditorTask(project, mainExtension)
-
-            val configs = getConfigs(this.productFlavors.map { it.second }, this.buildType)
+            val configs = getConfigs(it.productFlavors.map { it.second }, it.buildType)
 
             generatePoEditorTasks(configs,
                 project,
@@ -121,16 +122,17 @@ class PoEditorPlugin : Plugin<Project> {
         // configurations with Android library modules.
         val configsExtensionContainer = project.container<PoEditorPluginExtension>()
         val androidExtension = project.the<LibraryExtension>()
+        val androidComponentsExtension = project.the<LibraryAndroidComponentsExtension>()
         (androidExtension as ExtensionAware).extensions.add(POEDITOR_CONFIG_NAME, configsExtensionContainer)
 
         val configPoEditorTaskProvidersMap: MutableMap<ConfigName, TaskProvider<*>> = mutableMapOf()
 
         // Add tasks for every flavor or build type
-        androidExtension.onVariants {
+        androidComponentsExtension.beforeVariants {
             // Add main extension since we have the main extension evaluated here
             addMainPoEditorTask(project, mainExtension)
 
-            val configs = getConfigs(this.productFlavors.map { it.second }, this.buildType)
+            val configs = getConfigs(it.productFlavors.map { it.second }, it.buildType)
 
             generatePoEditorTasks(configs,
                 project,


### PR DESCRIPTION
### PR's key points
The PR adds support for the new Gradle Plugin added in Android Studio 4.2, now stable. The changes suppose that we have to drop support for old Gradle versions, though.
 
### Definition of Done
- [ ] Tests added (if new code is added)
- [ ] There is no outcommented or debug code left
