### PR TITLE
Add languageValuesOverridePathMap to override values folder for specific languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- No new features!
+- Add `languageValuesOverridePathMap` to override `values` folder for specific languages.
+<details open><summary>Groovy</summary>
+
+```groovy
+poEditor {
+  apiToken = "your_api_token"
+  projectId = 12345
+  defaultLang = "en"
+  languageValuesOverridePathMap = [
+          "free" : "${rootDir}/app/src/free/res/values",
+          "paid" : "${rootDir}/app/src/paid/res/values"
+  ]
+}
+```
+
+</details>
+
+<details><summary>Kotlin</summary>
+
+```kotlin
+poEditor {
+  apiToken = "your_api_token"
+  projectId = 12345
+  defaultLang = "en"
+  languageValuesOverridePathMap = mapOf(
+          "free" to "${rootDir}/app/src/free/res/values",
+          "paid" to "${rootDir}/app/src/paid/res/values"
+  )
+}
+```
 ### Changed
 - No changed features!
 ### Deprecated
@@ -45,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.1.0] - 2021-05-05
 ### Added
 - Add `tags` parameter to `poEditorConfig` block to add PoEditor tags:
+<details open><summary>Groovy</summary>
+
 ```groovy
 poEditor {
   apiToken = "your_api_token"
@@ -53,6 +84,20 @@ poEditor {
   tags = ["tag1", "tag2"] // Download strings with the specified tags
 }
 ```
+
+</details>
+
+<details><summary>Kotlin</summary>
+
+```kotlin
+poEditor {
+  apiToken = "your_api_token"
+  projectId = 12345
+  defaultLang = "en"
+  tags = listOf("tag1", "tag2")
+}
+```
+
 ### Changed
 - Add support for Android Gradle Plugin version 4.2.0
 ### Removed

--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ android {
 You can also select the tags that you want strings to be downloaded from PoEditor, based on the tags that you defined in
 your PoEditor project.
 
+<details open><summary>Groovy</summary>
+
 ```groovy
 poEditor {
     apiToken = "your_api_token"
@@ -383,6 +385,10 @@ poEditor {
 }
 ```
 
+</details>
+
+<details><summary>Kotlin</summary>    
+    
 ```kotlin
 poEditor {
     apiToken = "your_api_token"
@@ -391,6 +397,8 @@ poEditor {
     tags = listOf("tag1", "tag2")
 }
 ```
+    
+</details>
 
 ## Overriding default values folder for specific languages
 > Requires version 2.2.0 of the plug-in
@@ -404,6 +412,8 @@ flavors.
 You can add the parameter `languageValuesOverridePathMap` to your `poEditor` or `poEditorConfig` block to change the 
 path of the `values` folder where the strings file will be stored for a given language code:
 
+<details open><summary>Groovy</summary>
+
 ```groovy
 poEditor {
     apiToken = "your_api_token"
@@ -415,6 +425,10 @@ poEditor {
     ]
 }
 ```
+    
+</details>
+
+<details><summary>Kotlin</summary>
 
 ```kotlin
 poEditor {
@@ -427,6 +441,8 @@ poEditor {
     )
 }
 ```
+    
+</details>
 
 ## iOS alternative
 If you want a similar solution for your iOS projects, check this out: [poeditor-parser-swift](https://github.com/hyperdevs-team/poeditor-parser-swift)

--- a/README.md
+++ b/README.md
@@ -76,14 +76,15 @@ poEditor {
 
 The complete attribute list is the following:
 
-Attribute                     | Description
-------------------------------|-----------------------------------------
-```apiToken```                | PoEditor API Token.
-```projectId```               | PoEditor project ID.
-```defaultLang```             | (Optional) The lang to be used to build default ```strings.xml``` (```/values``` folder). Defaults to English (`en`).
-```defaultResPath```          | (Since 1.3.0) (Optional) Path where the plug-in should dump strings. Defaults to the module's default (or build variant) `res` path.
-```enabled```                 | (Since 1.4.0) (Optional) Enables the generation of the block's related task. Defaults to `true`.
-```tags```                    | (Since 2.1.0) (Optional) List of PoEditor tags to download.
+Attribute                       | Description
+--------------------------------|-----------------------------------------
+```apiToken```                  | PoEditor API Token.
+```projectId```                 | PoEditor project ID.
+```defaultLang```               | (Optional) The lang to be used to build default ```strings.xml``` (```/values``` folder). Defaults to English (`en`).
+```defaultResPath```            | (Since 1.3.0) (Optional) Path where the plug-in should dump strings. Defaults to the module's default (or build variant) `res` path.
+```enabled```                   | (Since 1.4.0) (Optional) Enables the generation of the block's related task. Defaults to `true`.
+```tags```                      | (Since 2.1.0) (Optional) List of PoEditor tags to download. Defaults to empty list.
+```languageValuesOverrideMap``` | (Since 2.2.0) (Optional) Map of `language_code:path` entries that you want to override the default language values folder with. Defaults to empty map.
 
 After the configuration is done, just run the new ```importPoEditorStrings``` task via Android Studio or command line:
 
@@ -379,6 +380,51 @@ poEditor {
     projectId = 12345
     defaultLang = "en"
     tags = ["tag1", "tag2"] // Download strings with the specified tags
+}
+```
+
+```kotlin
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    tags = listOf("tag1", "tag2")
+}
+```
+
+## Overriding default values folder for specific languages
+> Requires version 2.2.0 of the plug-in
+
+Sometimes you may want to override the default `values` path where the plug-in stores the downloaded strings.
+For example, you may have a project where you have custom languages suited to your app flavors in PoEditor
+(let's say `free` and `paid`). The plug-in would create two folders in your app's `res` folder 
+(`values-free` and `values-paid`) by default; this would not be ideal if you want the string values to their respective
+flavors.
+
+You can add the parameter `languageValuesOverridePathMap` to your `poEditor` or `poEditorConfig` block to change the 
+path of the `values` folder where the strings file will be stored for a given language code:
+
+```groovy
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    languageValuesOverridePathMap = [
+            "free" : "${rootDir}/app/src/free/res/values", 
+            "paid" : "${rootDir}/app/src/paid/res/values"
+    ]
+}
+```
+
+```kotlin
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    languageValuesOverridePathMap = mapOf(
+        "free" to "${rootDir}/app/src/free/res/values",
+        "paid" to "${rootDir}/app/src/paid/res/values"
+    )
 }
 ```
 

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
@@ -23,7 +23,7 @@ import io.github.cdimascio.dotenv.Dotenv
 /**
  * Only for testing purposes.
  *
- * Declare the variables API_TOKEN, PROJECT_ID, RES_DIR_PATH and DEFAULT_LANGUAGE in /.env
+ * Declare the variables API_TOKEN, PROJECT_ID, RES_DIR_PATH, DEFAULT_LANGUAGE in /.env
  */
 @Suppress("MagicNumber")
 fun main() {
@@ -33,7 +33,24 @@ fun main() {
     val projectId = dotenv.get("PROJECT_ID", "-1").toInt()
     val resDirPath = dotenv.get("RES_DIR_PATH", "")
     val defaultLanguage = dotenv.get("DEFAULT_LANGUAGE", "")
-    val tags = dotenv.get("TAGS", "").takeIf { it.isNotBlank() }?.split(",")?.map { it.trim() }
+    val tags = dotenv.get("TAGS", "")
+        .takeIf { it.isNotBlank() }
+        ?.split(",")
+        ?.map { it.trim() }
+    val languageValuesOverridePathMap = dotenv.get("LANGUAGE_VALUES_OVERRIDE_PATH_MAP", "")
+        .takeIf { it.isNotBlank() }
+        ?.split(",")
+        ?.associate {
+            val (key, value) = it.split(":")
+            key to value
+        }
 
-    PoEditorStringsImporter.importPoEditorStrings(apiToken, projectId, defaultLanguage, resDirPath, tags)
+    PoEditorStringsImporter.importPoEditorStrings(
+        apiToken,
+        projectId,
+        defaultLanguage,
+        resDirPath,
+        tags,
+        languageValuesOverridePathMap
+    )
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
@@ -53,6 +53,7 @@ class PoEditorPlugin : Plugin<Project> {
                 defaultLang.convention("en")
                 defaultResPath.convention(mainResourceDirectory.asFile.absolutePath)
                 tags.convention(emptyList())
+                languageValuesOverridePathMap.convention(emptyMap())
             }
 
         // Add flavor and build-type configurations if the project has the "com.android.application" plugin

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
@@ -21,6 +21,7 @@ package com.hyperdevs.poeditor.gradle
 import org.gradle.api.Named
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -87,6 +88,16 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
     val tags: ListProperty<String> = objects.listProperty(String::class.java)
 
     /**
+     * Map of languages to override their default values folder.
+     *
+     * Defaults to an empty map of language overrides map.
+     */
+    @get:Optional
+    @get:Input
+    val languageValuesOverridePathMap: MapProperty<String, String> =
+        objects.mapProperty(String::class.java, String::class.java)
+
+    /**
      * Sets the configuration as enabled or not.
      *
      * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
@@ -145,4 +156,14 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
      * Gradle Kotlin DSL users must use `tags.set(value)`.
      */
     fun setTags(value: List<String>) = tags.set(value)
+
+    /**
+     * Sets the map of languages to override their default values folder.
+     *
+     * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
+     * https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties for more details.
+     *
+     * Gradle Kotlin DSL users must use `languageOverridePathMap.set(value)`.
+     */
+    fun setLanguageValuesOverridePathMap(value: Map<String, String>) = languageValuesOverridePathMap.set(value)
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
@@ -71,7 +71,8 @@ object PoEditorStringsImporter {
                               projectId: Int,
                               defaultLang: String,
                               resDirPath: String,
-                              tags: List<String>?) {
+                              tags: List<String>?,
+                              languageValuesOverridePathMap: Map<String, String>?) {
         try {
             val poEditorApiController = PoEditorApiControllerImpl(apiToken, poEditorApi)
 
@@ -103,7 +104,12 @@ object PoEditorStringsImporter {
                         translationFile, listOf(TABLET_REGEX_STRING))
 
                 xmlWriter.saveXml(
-                    resDirPath, postProcessedXmlDocumentMap, defaultLang, languageCode)
+                    resDirPath,
+                    postProcessedXmlDocumentMap,
+                    defaultLang,
+                    languageCode,
+                    languageValuesOverridePathMap
+                )
             }
         } catch (e: Exception) {
             logger.error("An error happened when retrieving strings from project. " +

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -46,6 +46,7 @@ abstract class ImportPoEditorStringsTask
         val defaultLang: String
         val defaultResPath: String
         val tags : List<String>
+        val languageOverridePathMap: Map<String, String>
 
         try {
             apiToken = extension.apiToken.get()
@@ -53,6 +54,7 @@ abstract class ImportPoEditorStringsTask
             defaultLang = extension.defaultLang.get()
             defaultResPath = extension.defaultResPath.get()
             tags = extension.tags.get()
+            languageOverridePathMap = extension.languageValuesOverridePathMap.get()
         } catch (e: Exception) {
             logger.error("Import configuration failed", e)
 
@@ -63,6 +65,11 @@ abstract class ImportPoEditorStringsTask
         }
 
         PoEditorStringsImporter.importPoEditorStrings(
-            apiToken, projectId, defaultLang, defaultResPath, tags)
+            apiToken,
+            projectId,
+            defaultLang,
+            defaultResPath,
+            tags,
+            languageOverridePathMap)
     }
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/utils/ExtensionsUtils.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/utils/ExtensionsUtils.kt
@@ -22,6 +22,7 @@ import com.hyperdevs.poeditor.gradle.PoEditorPluginExtension
 import com.hyperdevs.poeditor.gradle.TAG
 import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.newInstance
 import java.util.*
@@ -78,6 +79,17 @@ private fun <T> Collection<KProperty1<T, *>>.linkProperties(parent: T, child: T,
         } else if (value is ListProperty<*>) {
             val originalProperty = property.get(child) as ListProperty<Nothing>
             val parentFallback = property.get(parent) as ListProperty<Nothing>
+            if (value !== parentFallback) {
+                value.set(originalProperty.map {
+                    it.takeUnless { it.isEmpty() }.sneakyNull()
+                }.orElse(parentFallback))
+            } else {
+                value.set(originalProperty)
+            }
+        } else if (value is MapProperty<*, *>) {
+            val originalProperty = property.get(child) as MapProperty<Nothing, Nothing>
+            val parentFallback = property.get(parent) as MapProperty<Nothing, Nothing>
+
             if (value !== parentFallback) {
                 value.set(originalProperty.map {
                     it.takeUnless { it.isEmpty() }.sneakyNull()

--- a/src/test/kotlin/com/hyperdevs/poeditor/gradle/utils/MergeExtensionsTest.kt
+++ b/src/test/kotlin/com/hyperdevs/poeditor/gradle/utils/MergeExtensionsTest.kt
@@ -66,6 +66,7 @@ class MergeExtensionsTest {
         val testProjectId0 = 1234
         val testProjectId1 = 2345
         val testDefaultLang = "es"
+        val testLanguageValuesOverridePathMap = mapOf("es" to "test/folder")
 
         val child = Extension().apply {
             apiToken.set(testApiToken)
@@ -74,6 +75,7 @@ class MergeExtensionsTest {
         val parent = Extension().apply {
             projectId.set(testProjectId1)
             defaultLang.set(testDefaultLang)
+            languageValuesOverridePathMap.set(testLanguageValuesOverridePathMap)
         }
         val exts = listOf(child, parent).mapToExtensionMergeHolder(project)
 
@@ -82,6 +84,7 @@ class MergeExtensionsTest {
         assertEquals(testApiToken, merged.apiToken.get())
         assertEquals(testProjectId0, merged.projectId.get())
         assertEquals(testDefaultLang, merged.defaultLang.get())
+        assertEquals(testLanguageValuesOverridePathMap, merged.languageValuesOverridePathMap.get())
     }
 
     @Test
@@ -89,10 +92,14 @@ class MergeExtensionsTest {
         val testApiToken = "test"
         val testProjectId = 1234
         val testDefaultLang = "es"
+        val testLanguageValuesOverridePathMap = mapOf("es" to "test/folder")
 
         val grandchild = Extension().apply { apiToken.set(testApiToken) }
         val child = Extension().apply { projectId.set(testProjectId) }
-        val parent = Extension().apply { defaultLang.set(testDefaultLang) }
+        val parent = Extension().apply {
+            defaultLang.set(testDefaultLang)
+            languageValuesOverridePathMap.set(testLanguageValuesOverridePathMap)
+        }
         val exts = listOf(grandchild, child, parent).mapToExtensionMergeHolder(project)
 
         val merged = mergeExtensions(exts)


### PR DESCRIPTION
### PR's key points
Copying and pasting from the updated README:

Sometimes you may want to override the default `values` path where the plug-in stores the downloaded strings.
For example, you may have a project where you have custom languages suited to your app flavors in PoEditor
(let's say `free` and `paid`). The plug-in would create two folders in your app's `res` folder 
(`values-free` and `values-paid`) by default; this would not be ideal if you want the string values to their respective
flavors.

You can add the parameter `languageValuesOverridePathMap` to your `poEditor` or `poEditorConfig` block to change the 
path of the `values` folder where the strings file will be stored for a given language code:

<details open><summary>Groovy</summary>

```groovy
poEditor {
    apiToken = "your_api_token"
    projectId = 12345
    defaultLang = "en"
    languageValuesOverridePathMap = [
            "free" : "${rootDir}/app/src/free/res/values", 
            "paid" : "${rootDir}/app/src/paid/res/values"
    ]
}
```
    
</details>

<details><summary>Kotlin</summary>

```kotlin
poEditor {
    apiToken = "your_api_token"
    projectId = 12345
    defaultLang = "en"
    languageValuesOverridePathMap = mapOf(
        "free" to "${rootDir}/app/src/free/res/values",
        "paid" to "${rootDir}/app/src/paid/res/values"
    )
}
```
    
</details>
 
### How to review this PR?

Test this new configuration to set-up languages in specific folders.
  
### Definition of Done
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
