### PR TITLE
Increase connect, read and write timeouts to 30 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - No new features!
 ### Changed
-- No changed features!
+- Increase connect, read and write timeouts to 30 seconds
 ### Deprecated
 - No deprecated features!
 ### Removed

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
@@ -34,6 +34,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import java.util.*
+import java.util.concurrent.TimeUnit
 
 /**
  * Main class that does the XML download, parsing and saving from PoEditor files.
@@ -46,7 +47,13 @@ object PoEditorStringsImporter {
         .add(Date::class.java, DateJsonAdapter())
         .build()
 
+    private const val CONNECT_TIMEOUT_SECONDS = 30L
+    private const val READ_TIMEOUT_SECONDS = 30L
+    private const val WRITE_TIMEOUT_SECONDS = 30L
     private val okHttpClient = OkHttpClient.Builder()
+        .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .writeTimeout(WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .addInterceptor(HttpLoggingInterceptor(object : HttpLoggingInterceptor.Logger {
             override fun log(message: String) {
                 logger.debug(message)


### PR DESCRIPTION
### Github issue
Resolves #29 

### PR's key points
Basically, increase timeouts from 10s (the default values) to 30s
 
### Definition of Done
- [ ] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
