### PR TITLE
Changed the xml encoding to lowercase "utf-8"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - No new features!
 ### Changed
-- No changed features!
+- The xml attribute "encoding" in the generated string resource files is now lowercase "utf-8"
 ### Deprecated
 - No deprecated features!
 ### Removed

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/ktx/DocumentExtensions.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/ktx/DocumentExtensions.kt
@@ -41,7 +41,7 @@ fun String.toDocument(): Document =
 fun Document.toAndroidXmlString(): String {
     val registry = DOMImplementationRegistry.newInstance()
     val impl = registry.getDOMImplementation("LS") as DOMImplementationLS
-    val output = impl.createLSOutput().apply { encoding = "UTF-8" }
+    val output = impl.createLSOutput().apply { encoding = "utf-8" }
     val serializer = impl.createLSSerializer()
 
     val writer = StringWriter()


### PR DESCRIPTION
### PR's key points
Changed the xml encoding to lowercase "utf-8" which is more common. 
 
### How to review this PR?
Notice that other xml files in an Android project have the "utf-8" encoding in lowercase.
 
### Definition of Done
- [ ] Tests added (if new code is added) - does not apply
- [x] There is no outcommented or debug code left