### PR TITLE
Add property to specify filters for all languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- No new features!
+- Add `filters` parameter to `poEditorConfig` block to specify the POEditor filters to use for all languages.
 ### Changed
 - No changed features!
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Attribute                          | Description
 ```tags```                         | (Since 2.1.0) (Optional) List of PoEditor tags to download. Defaults to empty list.
 ```languageValuesOverrideMap```    | (Since 2.2.0) (Optional) Map of `language_code:path` entries that you want to override the default language values folder with. Defaults to empty map.
 ```minimumTranslationPercentage``` | (Since 2.3.0) (Optional) The minimum accepted percentage of translated strings per language. Languages with fewer translated strings will not be fetched. Defaults to no minimum, allowing all languages to be fetched.
+```filters```                      | (Since TBD) (Optional) List of PoEditor filters to use during download. Defaults to empty list. Accepted values are defined by the POEditor API.
 
 After the configuration is done, just run the new ```importPoEditorStrings``` task via Android Studio or command line:
 
@@ -471,6 +472,41 @@ poEditor {
     projectId = 12345
     defaultLang = "en"
     minimumTranslationPercentage = 85
+}
+```
+    
+</details>
+
+
+## Handling filters
+> Requires version TBD of the plug-in
+
+The plug-in also allows setting filters for narrowing down the type of terms to be downloaded. 
+Supported filters are defined by the POEditor API and currently include: 'translated', 'untranslated', 'fuzzy', 'not_fuzzy', 'automatic', 'not_automatic', 'proofread', 'not_proofread'. 
+At the moment it's not possible to set different filters per language.  
+This is set-up with the optional `filters` parameter in your `poEditor` or `poEditorConfig` blocks:
+
+<details open><summary>Groovy</summary>
+
+```groovy
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    filters = ["translated", "not_fuzzy"]
+}
+```
+    
+</details>
+
+<details><summary>Kotlin</summary>
+
+```kotlin
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    filters = listOf("translated", "not_fuzzy")
 }
 ```
     

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
@@ -33,6 +33,11 @@ fun main() {
     val projectId = dotenv.get("PROJECT_ID", "-1").toInt()
     val resDirPath = dotenv.get("RES_DIR_PATH", "")
     val defaultLanguage = dotenv.get("DEFAULT_LANGUAGE", "")
+    val filters = dotenv.get("FILTERS", "")
+        .takeIf { it.isNotBlank() }
+        ?.split(",")
+        ?.map { it.trim() }
+        ?: emptyList()
     val tags = dotenv.get("TAGS", "")
         .takeIf { it.isNotBlank() }
         ?.split(",")
@@ -53,6 +58,7 @@ fun main() {
         projectId,
         defaultLanguage,
         resDirPath,
+        filters,
         tags,
         languageValuesOverridePathMap,
         minimumTranslationPercentage

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
@@ -52,6 +52,7 @@ class PoEditorPlugin : Plugin<Project> {
                 enabled.convention(true)
                 defaultLang.convention("en")
                 defaultResPath.convention(mainResourceDirectory.asFile.absolutePath)
+                filters.convention(emptyList())
                 tags.convention(emptyList())
                 languageValuesOverridePathMap.convention(emptyMap())
                 minimumTranslationPercentage.convention(-1)

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
@@ -79,6 +79,15 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
     val defaultResPath: Property<String> = objects.property(String::class.java)
 
     /**
+     * Filters to limit downloaded strings with, from the officially supported list in PoEditor.
+     *
+     * Defaults to an empty list of filters if not present.
+     */
+    @get:Optional
+    @get:Input
+    val filters: ListProperty<String> = objects.listProperty(String::class.java)
+
+    /**
      * Tags to filter downloaded strings with, previously declared in PoEditor.
      *
      * Defaults to an empty list of tags if not present.
@@ -155,6 +164,16 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
      * Gradle Kotlin DSL users must use `defaultResPath.set(value)`.
      */
     fun setDefaultResPath(value: String) = defaultResPath.set(value)
+
+    /**
+     * Sets the filters to limit downloaded strings with, from the officially supported list in PoEditor.
+     *
+     * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
+     * https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties for more details.
+     *
+     * Gradle Kotlin DSL users must use `filters.set(value)`.
+     */
+    fun setFilters(value: List<String>) = filters.set(value)
 
     /**
      * Sets the tags to filter downloaded strings with, previously declared in PoEditor.

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
@@ -81,6 +81,7 @@ object PoEditorStringsImporter {
                               projectId: Int,
                               defaultLang: String,
                               resDirPath: String,
+                              filters: List<String>,
                               tags: List<String>,
                               languageValuesOverridePathMap: Map<String, String>,
                               minimumTranslationPercentage: Int) {
@@ -106,6 +107,10 @@ object PoEditorStringsImporter {
                 logger.lifecycle(skippedLanguagesMessage)
             }
 
+            if (filters.isNotEmpty()) {
+                logger.lifecycle("Using the following filters for all languages: $filters")
+            }
+
             projectLanguages.minus(skippedLanguages).forEach { languageData ->
                 val languageCode = languageData.code
 
@@ -116,6 +121,7 @@ object PoEditorStringsImporter {
                     projectId = projectId,
                     code = languageCode,
                     type = ExportType.ANDROID_STRINGS,
+                    filters = filters,
                     tags = tags)
 
                 // Download translation File to in-memory string

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/PoEditorApiController.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/PoEditorApiController.kt
@@ -40,6 +40,7 @@ interface PoEditorApiController {
     fun getTranslationFileUrl(projectId: Int,
                               code: String,
                               type: ExportType,
+                              filters: List<String>?,
                               tags: List<String>?): String
 }
 
@@ -55,11 +56,16 @@ class PoEditorApiControllerImpl(private val apiToken: String,
         return response.onSuccessful { it.result.languages }
     }
 
-    override fun getTranslationFileUrl(projectId: Int, code: String, type: ExportType, tags: List<String>?): String {
+    override fun getTranslationFileUrl(projectId: Int,
+                                       code: String,
+                                       type: ExportType,
+                                       filters: List<String>?,
+                                       tags: List<String>?): String {
         val response = poEditorApi.getExportFileInfo(
             apiToken = apiToken,
             id = projectId,
             type = type.toString().toLowerCase(),
+            filters = filters,
             language = code,
             tags = tags)
             .execute()

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/api/PoEditorApi.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/api/PoEditorApi.kt
@@ -19,7 +19,9 @@
 package com.hyperdevs.poeditor.gradle.network.api
 
 import retrofit2.Call
-import retrofit2.http.*
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.POST
 
 /**
  * API declaration of PoEditor endpoints used in the app.

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -45,6 +45,7 @@ abstract class ImportPoEditorStringsTask
         val projectId: Int
         val defaultLang: String
         val defaultResPath: String
+        val filters: List<String>
         val tags: List<String>
         val languageOverridePathMap: Map<String, String>
         val minimumTranslationPercentage: Int
@@ -54,6 +55,7 @@ abstract class ImportPoEditorStringsTask
             projectId = extension.projectId.get()
             defaultLang = extension.defaultLang.get()
             defaultResPath = extension.defaultResPath.get()
+            filters = extension.filters.get()
             tags = extension.tags.get()
             languageOverridePathMap = extension.languageValuesOverridePathMap.get()
             minimumTranslationPercentage = extension.minimumTranslationPercentage.get()
@@ -71,6 +73,7 @@ abstract class ImportPoEditorStringsTask
             projectId,
             defaultLang,
             defaultResPath,
+            filters,
             tags,
             languageOverridePathMap,
             minimumTranslationPercentage)


### PR DESCRIPTION
### PR's key points
- Add an optional property that allows you to send POEditor filters when fetching terms
- Supported filters are determined by the POEditor API v2. In my testing, sending an unsupported filter does not raise an error, but the filter gets ignored. (not documented on POEditor)
- The property applies to all languages (also to the default language. Note that in a simple Android project you'll get an error at build time if a used string is missing from the base language, so it's safe at runtime)
- Logging the filters when running the task, if set
- Filtering the terms server-side via this property results in faster fetching
- Edited the Readme and the Changelog, but they are not final

Potential use case: Fetch only translated terms. This way we don't have to clean up the xml from empty terms afterwards.

Future improvements: 
- allow to also specify filters per language (optionally)
 
### Related issues
https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/issues/32

### How to review this PR?
https://poeditor.com/docs/api#projects_export

### Definition of Done
- [ ] Tests added (if new code is added) - decided against adding tests, as it's simply using a documented API property
- [x] There is no outcommented or debug code left
