### PR TITLE
Add property to fetch only languages that are translated over a certain percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add some code style rules to be shared via editorconfig (insert_final_newline=false)
+- Add `minimumTranslationPercentage` parameter to `poEditorConfig` block to specify the minimum accepted percentage of translated strings per language
 ### Changed
 - The xml attribute "encoding" in the generated string resource files is now lowercase "utf-8"
 - Migrate to PoEditor API v2

--- a/README.md
+++ b/README.md
@@ -76,15 +76,16 @@ poEditor {
 
 The complete attribute list is the following:
 
-Attribute                       | Description
---------------------------------|-----------------------------------------
-```apiToken```                  | PoEditor API Token.
-```projectId```                 | PoEditor project ID.
-```defaultLang```               | (Optional) The lang to be used to build default ```strings.xml``` (```/values``` folder). Defaults to English (`en`).
-```defaultResPath```            | (Since 1.3.0) (Optional) Path where the plug-in should dump strings. Defaults to the module's default (or build variant) `res` path.
-```enabled```                   | (Since 1.4.0) (Optional) Enables the generation of the block's related task. Defaults to `true`.
-```tags```                      | (Since 2.1.0) (Optional) List of PoEditor tags to download. Defaults to empty list.
-```languageValuesOverrideMap``` | (Since 2.2.0) (Optional) Map of `language_code:path` entries that you want to override the default language values folder with. Defaults to empty map.
+Attribute                          | Description
+-----------------------------------|-----------------------------------------
+```apiToken```                     | PoEditor API Token.
+```projectId```                    | PoEditor project ID.
+```defaultLang```                  | (Optional) The lang to be used to build default ```strings.xml``` (```/values``` folder). Defaults to English (`en`).
+```defaultResPath```               | (Since 1.3.0) (Optional) Path where the plug-in should dump strings. Defaults to the module's default (or build variant) `res` path.
+```enabled```                      | (Since 1.4.0) (Optional) Enables the generation of the block's related task. Defaults to `true`.
+```tags```                         | (Since 2.1.0) (Optional) List of PoEditor tags to download. Defaults to empty list.
+```languageValuesOverrideMap```    | (Since 2.2.0) (Optional) Map of `language_code:path` entries that you want to override the default language values folder with. Defaults to empty map.
+```minimumTranslationPercentage``` | (TBD) (Optional) The minimum accepted percentage of translated strings per language. Languages with fewer translated strings will not be fetched. Defaults to no minimum, allowing all languages to be fetched.
 
 After the configuration is done, just run the new ```importPoEditorStrings``` task via Android Studio or command line:
 

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
@@ -44,6 +44,7 @@ fun main() {
             val (key, value) = it.split(":")
             key to value
         }
+    val minimumTranslationPercentage = dotenv.get("MINIMUM_TRANSLATION_PERCENTAGE", "85").toInt()
 
     PoEditorStringsImporter.importPoEditorStrings(
         apiToken,
@@ -51,6 +52,7 @@ fun main() {
         defaultLanguage,
         resDirPath,
         tags,
-        languageValuesOverridePathMap
+        languageValuesOverridePathMap,
+        minimumTranslationPercentage
     )
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
@@ -54,7 +54,7 @@ class PoEditorPlugin : Plugin<Project> {
                 defaultResPath.convention(mainResourceDirectory.asFile.absolutePath)
                 tags.convention(emptyList())
                 languageValuesOverridePathMap.convention(emptyMap())
-                minimumTranslationPercentage.convention(null)
+                minimumTranslationPercentage.convention(-1)
             }
 
         // Add flavor and build-type configurations if the project has the "com.android.application" plugin

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
@@ -54,6 +54,7 @@ class PoEditorPlugin : Plugin<Project> {
                 defaultResPath.convention(mainResourceDirectory.asFile.absolutePath)
                 tags.convention(emptyList())
                 languageValuesOverridePathMap.convention(emptyMap())
+                minimumTranslationPercentage.convention(null)
             }
 
         // Add flavor and build-type configurations if the project has the "com.android.application" plugin

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
@@ -42,7 +42,7 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
      */
     @get:Optional
     @get:Input
-    val enabled : Property<Boolean> = objects.property(Boolean::class.java)
+    val enabled: Property<Boolean> = objects.property(Boolean::class.java)
 
     /**
      * PoEditor API token.
@@ -98,12 +98,21 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
         objects.mapProperty(String::class.java, String::class.java)
 
     /**
+     * The minimum accepted percentage of translated strings per language. Languages with fewer translated strings will not be fetched.
+     *
+     * Defaults to no minimum if not present, meaning that all languages will be fetched.
+     */
+    @get:Optional
+    @get:Input
+    val minimumTranslationPercentage: Property<Int> = objects.property(Int::class.java)
+
+    /**
      * Sets the configuration as enabled or not.
      *
      * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
      * https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties for more details.
      *
-     * Gradle Kotlin DSL users must use `apiToken.set(value)`.
+     * Gradle Kotlin DSL users must use `enabled.set(value)`.
      */
     fun setEnabled(value: Boolean) = enabled.set(value)
 
@@ -163,7 +172,17 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
      * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
      * https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties for more details.
      *
-     * Gradle Kotlin DSL users must use `languageOverridePathMap.set(value)`.
+     * Gradle Kotlin DSL users must use `languageValuesOverridePathMap.set(value)`.
      */
     fun setLanguageValuesOverridePathMap(value: Map<String, String>) = languageValuesOverridePathMap.set(value)
+
+    /**
+     * Sets the minimum accepted percentage of translated strings per language.
+     *
+     * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
+     * https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties for more details.
+     *
+     * Gradle Kotlin DSL users must use `minimumTranslationPercentage.set(value)`.
+     */
+    fun setMinimumTranslationPercentage(value: Int) = minimumTranslationPercentage.set(value)
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
@@ -84,17 +84,13 @@ object PoEditorStringsImporter {
                               tags: List<String>?,
                               languageValuesOverridePathMap: Map<String, String>?,
                               minimumTranslationPercentage: Int) {
-        fun isPercentageTooLow(percentage: Double) = percentage < minimumTranslationPercentage
-        fun List<ProjectLanguage>.joinAndFormat(transform: ((ProjectLanguage) -> CharSequence)) =
-            joinToString(separator = ", ", prefix = "[", postfix = "]", transform = transform)
-
         try {
             val poEditorApiController = PoEditorApiControllerImpl(apiToken, poEditorApi)
 
             // Retrieve available languages from PoEditor
             logger.lifecycle("Retrieving project languages...")
             val projectLanguages = poEditorApiController.getProjectLanguages(projectId)
-            val skippedLanguages = projectLanguages.filter { language -> isPercentageTooLow(language.percentage) }
+            val skippedLanguages = projectLanguages.filter { language -> language.percentage < minimumTranslationPercentage }
 
             // Iterate over every available language
             logger.lifecycle("Available languages: ${projectLanguages.joinAndFormat { it.code }}")
@@ -114,7 +110,7 @@ object PoEditorStringsImporter {
                 val languageCode = languageData.code
                 val percentage = languageData.percentage
 
-                if (isPercentageTooLow(percentage)) {
+                if (percentage < minimumTranslationPercentage) {
                     return@forEach
                 }
 
@@ -150,4 +146,7 @@ object PoEditorStringsImporter {
             throw e
         }
     }
+
+    private fun List<ProjectLanguage>.joinAndFormat(transform: ((ProjectLanguage) -> CharSequence)) =
+        joinToString(separator = ", ", prefix = "[", postfix = "]", transform = transform)
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
@@ -83,8 +83,8 @@ object PoEditorStringsImporter {
                               resDirPath: String,
                               tags: List<String>?,
                               languageValuesOverridePathMap: Map<String, String>?,
-                              minimumTranslationPercentage: Int?) {
-        fun isPercentageTooLow(percentage: Double) = percentage < minimumTranslationPercentage ?: -1
+                              minimumTranslationPercentage: Int) {
+        fun isPercentageTooLow(percentage: Double) = percentage < minimumTranslationPercentage
         fun List<ProjectLanguage>.joinAndFormat(transform: ((ProjectLanguage) -> CharSequence)) =
             joinToString(separator = ", ", prefix = "[", postfix = "]", transform = transform)
 
@@ -99,7 +99,7 @@ object PoEditorStringsImporter {
             // Iterate over every available language
             logger.lifecycle("Available languages: ${projectLanguages.joinAndFormat { it.code }}")
 
-            minimumTranslationPercentage?.run {
+            if (minimumTranslationPercentage > -1) {
                 val skippedLanguagesMessage = if (skippedLanguages.isEmpty()) {
                     "All languages are translated above the minimum of $minimumTranslationPercentage%"
                 } else {

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
@@ -90,7 +90,7 @@ object PoEditorStringsImporter {
             // Retrieve available languages from PoEditor
             logger.lifecycle("Retrieving project languages...")
             val projectLanguages = poEditorApiController.getProjectLanguages(projectId)
-            val skippedLanguages = projectLanguages.filter { language -> language.percentage < minimumTranslationPercentage }
+            val skippedLanguages = projectLanguages.filter { it.percentage < minimumTranslationPercentage }
 
             // Iterate over every available language
             logger.lifecycle("Available languages: ${projectLanguages.joinAndFormat { it.code }}")
@@ -106,13 +106,8 @@ object PoEditorStringsImporter {
                 logger.lifecycle(skippedLanguagesMessage)
             }
 
-            projectLanguages.forEach { languageData ->
+            projectLanguages.minus(skippedLanguages).forEach { languageData ->
                 val languageCode = languageData.code
-                val percentage = languageData.percentage
-
-                if (percentage < minimumTranslationPercentage) {
-                    return@forEach
-                }
 
                 // Retrieve translation file URL for the given language and for the "android_strings" type,
                 // acknowledging passed tags if present

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -45,8 +45,9 @@ abstract class ImportPoEditorStringsTask
         val projectId: Int
         val defaultLang: String
         val defaultResPath: String
-        val tags : List<String>
+        val tags: List<String>
         val languageOverridePathMap: Map<String, String>
+        val minimumTranslationPercentage: Int?
 
         try {
             apiToken = extension.apiToken.get()
@@ -55,6 +56,7 @@ abstract class ImportPoEditorStringsTask
             defaultResPath = extension.defaultResPath.get()
             tags = extension.tags.get()
             languageOverridePathMap = extension.languageValuesOverridePathMap.get()
+            minimumTranslationPercentage = extension.minimumTranslationPercentage.orNull
         } catch (e: Exception) {
             logger.error("Import configuration failed", e)
 
@@ -70,6 +72,7 @@ abstract class ImportPoEditorStringsTask
             defaultLang,
             defaultResPath,
             tags,
-            languageOverridePathMap)
+            languageOverridePathMap,
+            minimumTranslationPercentage)
     }
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -47,7 +47,7 @@ abstract class ImportPoEditorStringsTask
         val defaultResPath: String
         val tags: List<String>
         val languageOverridePathMap: Map<String, String>
-        val minimumTranslationPercentage: Int?
+        val minimumTranslationPercentage: Int
 
         try {
             apiToken = extension.apiToken.get()
@@ -56,7 +56,7 @@ abstract class ImportPoEditorStringsTask
             defaultResPath = extension.defaultResPath.get()
             tags = extension.tags.get()
             languageOverridePathMap = extension.languageValuesOverridePathMap.get()
-            minimumTranslationPercentage = extension.minimumTranslationPercentage.orNull
+            minimumTranslationPercentage = extension.minimumTranslationPercentage.get()
         } catch (e: Exception) {
             logger.error("Import configuration failed", e)
 


### PR DESCRIPTION
### PR's key points
- Add an optional Int property to let the user specify the desired minimum percentage
- Fetch only languages that are translated over that percentage. A possible use case is that you see those languages as sufficiently translated to be included in your app, and anything else is not ready yet. By using this feature you can automatically fetch only the "ready" languages. So you don't have to manually specify which languages to fetch and update this configuration over time.
- Print the languages that have been skipped, and their percentages.

Possible future improvements: 
- always fetch languages that are already in the project, regardless of their percentage. This way languages that you support will be kept updated, even when they fall below the minimum percentage
- display a warning in the above case - when a language that's already included in your project falls below the minimum percentage
 
### How to review this PR?
- I've tested it with no value, high value and low value. However, I would be more confident if someone else tests it, too.
- I'm exposing it as Int to keep it simple. I don't expect anyone to need it floating-point, but let me know if you disagree.
- The README entry needs a version (since)
 
### Definition of Done
- [ ] Tests added (if new code is added) - did not add tests because the class would need refactoring (DI) and has no tests yet anyway
- [x] There is no outcommented or debug code left
