### PR TITLE
Fix CDATA strings losing CDATA string. Properly unescape HTML tags' symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
+.idea/**/runConfigurations.xml
 
 # Generated files
 .idea/**/contentModel.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - No removed features!
 ### Fixed
-- No fixed issues!
+- Fix CDATA strings not parsed correctly
+- Fix `<` and `>` not getting properly unescaped in CDATA strings
 ### Security
 - No security issues fixed!
 

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/ktx/StringExtensions.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/ktx/StringExtensions.kt
@@ -18,9 +18,7 @@
 
 package com.hyperdevs.poeditor.gradle.ktx
 
-private val UNESCAPED_HTML_TAGS_REGEX = Regex("""&lt;([^.]*?)&gt;""")
-
 /**
  * Unescapes HTML tags from string.
  */
-fun String.unescapeHtmlTags() = this.replace(UNESCAPED_HTML_TAGS_REGEX, "<$1>")
+fun String.unescapeHtmlTags() = this.replace("&lt;", "<").replace("&gt;", ">")

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/XmlPostProcessor.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/XmlPostProcessor.kt
@@ -155,7 +155,7 @@ class XmlPostProcessor {
     }
 
     private fun processTextAndReplaceNodeContent(document: Document, nodeElement: Element, rootNode: Node?) {
-        // First check if we have a CDATA node as the first child of the element. if we have it, we have to
+        // First check if we have a CDATA node as the a child of the element. If we have it, we have to
         // preserve the CDATA node but process the text. Else, we handle the node as a usual text node
         val copiedNodeElement: Element
         val (cDataNode, cDataPosition) = getCDataChildForNode(nodeElement)

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/XmlPostProcessor.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/XmlPostProcessor.kt
@@ -22,10 +22,7 @@ import com.hyperdevs.poeditor.gradle.ktx.toAndroidXmlString
 import com.hyperdevs.poeditor.gradle.ktx.toStringsXmlDocument
 import com.hyperdevs.poeditor.gradle.ktx.unescapeHtmlTags
 import com.hyperdevs.poeditor.gradle.utils.ALL_REGEX_STRING
-import org.w3c.dom.Document
-import org.w3c.dom.Element
-import org.w3c.dom.Node
-import org.w3c.dom.NodeList
+import org.w3c.dom.*
 
 /**
  * Class that handles XML transformation.
@@ -158,13 +155,40 @@ class XmlPostProcessor {
     }
 
     private fun processTextAndReplaceNodeContent(document: Document, nodeElement: Element, rootNode: Node?) {
-        val content = nodeElement.textContent
-        val processedContent = formatTranslationString(content)
-        val copiedNodeElement = (nodeElement.cloneNode(true) as Element).apply {
-            textContent = processedContent
+        // First check if we have a CDATA node as the first child of the element. if we have it, we have to
+        // preserve the CDATA node but process the text. Else, we handle the node as a usual text node
+        val copiedNodeElement: Element
+        val (cDataNode, cDataPosition) = getCDataChildForNode(nodeElement)
+        if (cDataNode != null) {
+            val cDataContent = cDataNode.textContent
+            val processedCDataContent = formatTranslationString(cDataContent)
+            val copiedCDataNode = (cDataNode.cloneNode(true) as CDATASection).apply {
+                this.data = processedCDataContent
+            }
+            copiedNodeElement = (nodeElement.cloneNode(true) as Element).apply {
+                replaceChild(copiedCDataNode, this.childNodes.item(cDataPosition))
+            }
+        } else {
+            val content = nodeElement.textContent
+            val processedContent = formatTranslationString(content)
+            copiedNodeElement = (nodeElement.cloneNode(true) as Element).apply {
+                textContent = processedContent
+            }
         }
+
         document.adoptNode(copiedNodeElement)
         rootNode?.replaceChild(copiedNodeElement, nodeElement)
+    }
+
+    private fun getCDataChildForNode(nodeElement: Element): Pair<Node?, Int> {
+        val childrenList = nodeElement.childNodes
+        for (i in 0..childrenList.length) {
+            val childNode = childrenList.item(i)
+            if (childNode is CDATASection) {
+                return Pair(childNode, i)
+            }
+        }
+        return Pair(null, -1)
     }
 
     @Suppress("NestedBlockDepth")

--- a/src/test/kotlin/com/hyperdevs/poeditor/gradle/xml/XmlPostProcessorTest.kt
+++ b/src/test/kotlin/com/hyperdevs/poeditor/gradle/xml/XmlPostProcessorTest.kt
@@ -318,6 +318,56 @@ class XmlPostProcessorTest {
     }
 
     @Test
+    fun `Postprocessing XML with CDATA works`() {
+        // Test complete Xml
+        val inputXmlString = """
+                            <resources>
+                              <string name="cdata">
+                                <![CDATA[Some text<a href="{{link}}">Link</a> text text]]>
+                              </string>
+                            </resources>
+                             """
+
+        val expectedResult = """
+                            <resources>
+                              <string name="cdata">
+                                <![CDATA[Some text<a href="%1${'$'}s">Link</a> text text]]>
+                              </string>
+                            </resources>
+                             """.formatXml()
+
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString))
+    }
+
+    @Test
+    fun `Postprocessing XML with multiline CDATA works`() {
+        // Test complete Xml
+        val inputXmlString = """
+                            <resources>
+                              <string name="cdata">
+                                <![CDATA[
+                                  <br />
+                                  <p><a href="mailto:{{email}}">ABC Email</a></p>
+                                ]]>
+                              </string>
+                            </resources>
+                             """
+
+        val expectedResult = """
+                            <resources>
+                              <string name="cdata">
+                                <![CDATA[
+                                  <br />
+                                  <p><a href="mailto:%1${'$'}s">ABC Email</a></p>
+                                ]]>
+                              </string>
+                            </resources>
+                             """.formatXml()
+
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString))
+    }
+
+    @Test
     fun `Splitting tablet translation strings works`() {
         // Test complete Xml
         val expectedKey = "general_button_goTop"


### PR DESCRIPTION
### Github issue (delete if this does not apply)
Resolves #44
Resolves #45 

### PR's key points
The PR fixes parsing for CDATA strings, as well as fixes some tags not getting parsed correctly by tweaking the `unescapeHtmlTags` method (suggested by @mfathy).
 
### How to review this PR?
Check that you can download CDATA strings from PoEditor and that its format is not lost
  
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
