### PR TITLE
Add support for Android Gradle Plugin 7.+. Upgrade dependencies and publishing mechanics

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-poeditor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - No security issues fixed!
 
+## [3.0.0] - 2022-02-02
+### Changed
+- BREAKING: Update dependencies to work with Android Gradle Plugin 7.+. This will break compatibility with
+projects that use versions lower than 7.0
+
 ## [2.4.2] - 2021-10-17
 ### Changed
 - Change detekt rules according to library update to version 1.18.1
 ### Removed
-- Remove `jcenter()` from project.
+- Remove `jcenter()` from project
 
 ## [2.4.1] - 2021-09-16
 ### Fixed
@@ -406,7 +411,8 @@ res_dir_path -> resDirPath
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/2.4.2...HEAD
+[Unreleased]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/3.0.0...HEAD
+[3.0.0]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/2.4.2...3.0.0
 [2.4.2]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/2.4.1...2.4.2
 [2.4.1]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/2.4.0...2.4.1
 [2.4.0]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/2.3.0...2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - No security issues fixed!
 
-## [3.0.0] - 2022-02-02
+## [3.0.0] - 2022-02-03
 ### Changed
 - BREAKING: Update dependencies to work with Android Gradle Plugin 7.+. This will break compatibility with
 projects that use versions lower than 7.0

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Simple plug-in that eases importing [PoEditor](https://poeditor.com) localized s
 This plug-in super-charges your Android project by providing tasks to download your localized strings from the PoEditor service into you Android project.
 It also provides a built-in syntax to handle placeholders to enhance the already awesome Android support from PoEditor.
 
+## Minimum requirements
+* Android Gradle Plug-in 7.0 or above
+
 ## Setting Up
 In your main `build.gradle`, add [jitpack.io](https://jitpack.io/) repository in the `buildscript` block and include the plug-in as a dependency:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,8 +127,6 @@ publishing {
             groupId = "com.github.hyperdevs-team"
             artifactId = "poeditor-android-gradle-plugin"
 
-            //from(components["java"])
-
             pom {
                 name.set("PoEditor Android Gradle Plug-in")
                 description.set("Gradle plug-in that enables importing PoEditor localized strings directly to an Android project")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,37 @@
+[versions]
+kotlin = "1.6.10"
+detekt = "1.19.0"
+moshi = "1.12.0"
+retrofit = "2.9.0"
+okhttp = "4.9.3"
+
+[libraries]
+android-buildTools = "com.android.tools.build:gradle:7.1.0"
+
+kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+
+moshi = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi"}
+moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi"}
+moshi-adapters = { group = "com.squareup.moshi", name = "moshi-adapters", version.ref = "moshi"}
+
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit"}
+retrofit-converterMoshi = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit"}
+
+okhttp3 = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp"}
+okhttp3-loggingInterceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp"}
+
+dotenvKotlin = "io.github.cdimascio:dotenv-kotlin:6.2.2"
+
+junit = "junit:junit:4.13.2"
+
+detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt"}
+
+[plugins]
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+gitVersionGradle = { id = "com.gladed.androidgitversion", version = "0.4.14"}
+
+[bundles]
+moshi = ["moshi", "moshi-kotlin", "moshi-adapters"]
+retrofit = ["retrofit", "retrofit-converterMoshi"]
+okhttp3 = ["okhttp3", "okhttp3-loggingInterceptor"]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,4 +16,6 @@
  * limitations under the License.
  */
 
-rootProject.name = "poeditor"
+enableFeaturePreview("VERSION_CATALOGS")
+
+rootProject.name = "poeditor-android-gradle-plugin"

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
@@ -18,8 +18,8 @@
 
 package com.hyperdevs.poeditor.gradle
 
-import com.android.build.api.extension.ApplicationAndroidComponentsExtension
-import com.android.build.api.extension.LibraryAndroidComponentsExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.LibraryPlugin


### PR DESCRIPTION
### Github issue
Resolves #50 

### PR's key points
The PR adds a series of improvements over the plugin's code:
* First and most importantly, it adds support for Android Gradle Plugin 7+. This means that backwards compatibility will be broken (hence the idea of bumping the version tag to 3.0.0).
* A lot of dependencies have been updated as a consequence of upgrading the plugin. I also took some time to migrate the versions' declaration to Gradle Version Catalogs.
* I also took some time to tweak the publishing code to add proper metadata to POM files. Nothing major, but I took advantage of having to migrate from the `maven` plugin to the `maven-publish` plugin due to the upgrade of the AGP version :P
  
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [x] Documentation added to README.md (if a new feature is added)
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
