### PR TITLE
Add unescapeHtmlTags flag and bump dependencies

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="1.8" />
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- No new features!
+- Add new `unescapeHtmlTags` flag to enable or disable HTML unescaping from strings.
+
+<details open><summary>Groovy</summary>
+
+```groovy
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    unescapeHtmlTags = false
+}
+```
+
+</details>
+
+<details><summary>Kotlin</summary>
+
+```kotlin
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    unescapeHtmlTags = false
+}
+```
+
+</details>
+
 ### Changed
 - No changed features!
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Attribute                              | Description
 ```resFileName```                      | (Since 3.1.0) (Optional) Sets the file name for the imported string resource XML files. Defaults to `strings`.
 ```order```                            | (Since 3.1.0) (Optional) Defines how to order the export. Accepted values are defined by the POEditor API.
 ```unquoted```                         | (Since 3.2.0) (Optional) Defines if the strings should be unquoted, overriding default PoEditor configuration. Defaults to `false`.
+```unescapeHtmlTags```                 | (Since 3.4.0) (Optional) Whether or not to unescape HTML entitites from strings. Defaults to true.
 
 After the configuration is done, just run the new ```importPoEditorStrings``` task via Android Studio or command line:
 
@@ -516,6 +517,37 @@ poEditor {
 }
 ```
     
+</details>
+
+## Toggling HTML unescaping
+> Requires version 3.4.0 of the plug-in
+
+You can enable or disable HTML tags unescaping with the `unescapeHtmlTags` flag.
+
+<details open><summary>Groovy</summary>
+
+```groovy
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    unescapeHtmlTags = false
+}
+```
+
+</details>
+
+<details><summary>Kotlin</summary>
+
+```kotlin
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    unescapeHtmlTags = false
+}
+```
+
 </details>
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,6 +135,21 @@ publishing {
                     }
                 }
 
+                organization {
+                    name.set("HyperDevs")
+                    url.set("https://github.com/hyperdevs-team")
+                }
+
+                issueManagement {
+                    system.set("GitHub Issues")
+                    url.set("https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/issues")
+                }
+
+                scm {
+                    connection.set("git@github.com:hyperdevs-team/poeditor-android-gradle-plugin.git")
+                    url.set("https://github.com/hyperdevs-team/poeditor-android-gradle-plugin.git")
+                }
+
                 developers {
                     developer {
                         name.set("Iván Martínez")
@@ -148,12 +163,6 @@ publishing {
                         id.set("adriangl")
                         url.set("https://github.com/adriangl")
                         roles.set(listOf("Maintainer"))
-
-                        organization {
-                            name.set("HyperDevs")
-                            id.set("hyperdevs-team")
-                            url.set("https://github.com/hyperdevs-team")
-                        }
                     }
                 }
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,6 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 gitVersionGradle = { id = "com.gladed.androidgitversion", version = "0.4.14"}
 versionsUpdate = { id = "com.github.ben-manes.versions", version = "0.46.0" }
 
-
 [bundles]
 moshi = ["moshi", "moshi-kotlin", "moshi-adapters"]
 retrofit = ["retrofit", "retrofit-converterMoshi"]

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
@@ -58,6 +58,7 @@ fun main() {
         ?: emptyMap()
     val minimumTranslationPercentage = dotenv.get("MINIMUM_TRANSLATION_PERCENTAGE", "85").toInt()
     val unquoted = dotenv.get("UNQUOTED", "false").toBoolean()
+    val unescapeHtmlTags = dotenv.get("UNESCAPE_HTML_TAGS", "true").toBoolean()
 
     PoEditorStringsImporter.importPoEditorStrings(
         apiToken,
@@ -70,6 +71,7 @@ fun main() {
         languageValuesOverridePathMap,
         minimumTranslationPercentage,
         resFileName,
-        unquoted
+        unquoted,
+        unescapeHtmlTags
     )
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
@@ -60,6 +60,7 @@ class PoEditorPlugin : Plugin<Project> {
                 minimumTranslationPercentage.convention(-1)
                 resFileName.convention("strings")
                 unquoted.convention(false)
+                unescapeHtmlTags.convention(true)
             }
 
         // Add flavor and build-type configurations if the project has the "com.android.application" plugin

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
@@ -143,6 +143,15 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
     val unquoted: Property<Boolean> = objects.property(Boolean::class.java)
 
     /**
+     * Whether or not HTML tags in strings should be unescaped or not.
+     *
+     * Defaults to true.
+     */
+    @get:Optional
+    @get:Input
+    val unescapeHtmlTags: Property<Boolean> = objects.property(Boolean::class.java)
+
+    /**
      * Sets the configuration as enabled or not.
      *
      * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
@@ -261,4 +270,14 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
      * Gradle Kotlin DSL users must use `unquoted.set(value)`.
      */
     fun setUnquoted(value: Boolean) = unquoted.set(value)
+
+    /**
+     * Sets if strings should have HTML tags unescaped.
+     *
+     * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
+     * https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties for more details.
+     *
+     * Gradle Kotlin DSL users must use `unescapeHtmlTags.set(value)`.
+     */
+    fun setUnescapeHtmlTags(value: Boolean) = unescapeHtmlTags.set(value)
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/ktx/DocumentExtensions.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/ktx/DocumentExtensions.kt
@@ -44,7 +44,7 @@ fun String.toStringsXmlDocument(): Document {
 /**
  * Converts a [Document] into a formatted [String].
  */
-fun Document.toAndroidXmlString(): String {
+fun Document.toAndroidXmlString(unescapeHtmlTags: kotlin.Boolean): String {
     val registry = DOMImplementationRegistry.newInstance()
     val impl = registry.getDOMImplementation("LS") as DOMImplementationLS
     val output = impl.createLSOutput().apply { encoding = "utf-8" }
@@ -59,5 +59,5 @@ fun Document.toAndroidXmlString(): String {
 
     serializer.write(this, output)
 
-    return writer.toString().unescapeHtmlTags()
+    return writer.toString().let { if (unescapeHtmlTags) it.unescapeHtmlTags() else it }
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/ktx/StringExtensions.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/ktx/StringExtensions.kt
@@ -21,4 +21,4 @@ package com.hyperdevs.poeditor.gradle.ktx
 /**
  * Unescapes HTML tags from string.
  */
-fun String.unescapeHtmlTags() = this.replace("&lt;", "<").replace("&gt;", ">")
+fun String.unescapeHtmlTags() = this.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -54,6 +54,7 @@ abstract class ImportPoEditorStringsTask
         val minimumTranslationPercentage: Int
         val resFileName: String
         val unquoted: Boolean
+        val unescapeHtmlTags: Boolean
 
         try {
             apiToken = extension.apiToken.get()
@@ -67,6 +68,7 @@ abstract class ImportPoEditorStringsTask
             minimumTranslationPercentage = extension.minimumTranslationPercentage.get()
             resFileName = extension.resFileName.get()
             unquoted = extension.unquoted.get()
+            unescapeHtmlTags = extension.unescapeHtmlTags.get()
         } catch (e: Exception) {
             logger.error("Import configuration failed", e)
 
@@ -87,6 +89,8 @@ abstract class ImportPoEditorStringsTask
             languageOverridePathMap,
             minimumTranslationPercentage,
             resFileName,
-            unquoted)
+            unquoted,
+            unescapeHtmlTags
+        )
     }
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/AndroidXmlWriter.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/AndroidXmlWriter.kt
@@ -41,7 +41,8 @@ class AndroidXmlWriter {
                 postProcessedXmlDocumentMap: Map<String, Document>,
                 defaultLang: String,
                 languageCode: String,
-                languageValuesOverridePathMap: Map<String, String>?) {
+                languageValuesOverridePathMap: Map<String, String>?,
+                unescapeHtmlTags: Boolean) {
         // First check if we have passed a default "values" folder for the given language
         var baseValuesDir: File? = languageValuesOverridePathMap?.get(languageCode)?.let { File(it) }
 
@@ -65,11 +66,14 @@ class AndroidXmlWriter {
         }
 
         folderToXmlMap.forEach { (valuesFolderFile, document) ->
-            saveXmlToFolder(valuesFolderFile, document, resFileName)
+            saveXmlToFolder(valuesFolderFile, document, resFileName, unescapeHtmlTags)
         }
     }
 
-    private fun saveXmlToFolder(stringsFolderFile: File, document: Document, resFileName: String) {
+    private fun saveXmlToFolder(stringsFolderFile: File,
+                                document: Document,
+                                resFileName: String,
+                                unescapeHtmlTags: Boolean) {
         if (!stringsFolderFile.exists()) {
             logger.debug("Creating strings folder for new language")
             val folderCreated = stringsFolderFile.mkdirs()
@@ -78,6 +82,6 @@ class AndroidXmlWriter {
         }
 
         logger.lifecycle("Saving strings to ${stringsFolderFile.absolutePath}")
-        File(stringsFolderFile, "$resFileName.xml").writeText(document.toAndroidXmlString())
+        File(stringsFolderFile, "$resFileName.xml").writeText(document.toAndroidXmlString(unescapeHtmlTags))
     }
 }

--- a/src/test/kotlin/com/hyperdevs/poeditor/gradle/xml/XmlPostProcessorTest.kt
+++ b/src/test/kotlin/com/hyperdevs/poeditor/gradle/xml/XmlPostProcessorTest.kt
@@ -91,13 +91,6 @@ class XmlPostProcessorTest {
     }
 
     @Test
-    fun `Postprocessing string HTML escapes sequences`() {
-        // Test Html tags are fixed
-        Assert.assertEquals("Hello <b>%1\$s</b>.",
-            xmlPostProcessor.formatTranslationString("Hello &lt;b&gt;{{name}}&lt;/b&gt;."))
-    }
-
-    @Test
     fun `Postprocessing complex XML works`() {
         // Test complete Xml
         val inputXmlString = """
@@ -132,9 +125,9 @@ class XmlPostProcessorTest {
                                 "Ir${'\n'}abajo"
                               </string>
                             </resources>
-                             """.trimIndent().formatXml()
+                             """.trimIndent().formatXml(true)
 
-        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString))
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString, true))
     }
 
     @Test
@@ -166,9 +159,9 @@ class XmlPostProcessorTest {
                                 "Hello. I love you 100%"
                               </string>
                             </resources>
-                             """.trimIndent().formatXml()
+                             """.trimIndent().formatXml(true)
 
-        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString))
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString, true))
     }
 
     @Test
@@ -190,9 +183,9 @@ class XmlPostProcessorTest {
                                 100%"
                               </string>
                             </resources>
-                             """.trimIndent().formatXml()
+                             """.trimIndent().formatXml(true)
 
-        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString))
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString, true))
     }
 
     @Test
@@ -214,9 +207,9 @@ class XmlPostProcessorTest {
                                 I love you 100%%"
                               </string>
                             </resources>
-                             """.trimIndent().formatXml()
+                             """.trimIndent().formatXml(true)
 
-        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString))
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString, true))
     }
 
     @Test
@@ -250,9 +243,9 @@ class XmlPostProcessorTest {
                                 <item quantity="other">"%1${'$'}s elementos seleccionados"</item>
                               </plurals>
                             </resources>
-                             """.trimIndent().formatXml()
+                             """.trimIndent().formatXml(true)
 
-        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString))
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString, true))
     }
 
     @Test
@@ -290,9 +283,9 @@ class XmlPostProcessorTest {
                                 <item quantity="other">"Hello friends. I love you 100%"</item>
                               </plurals>
                             </resources>
-                             """.trimIndent().formatXml()
+                             """.trimIndent().formatXml(true)
 
-        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString))
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString, true))
     }
 
     @Test
@@ -312,9 +305,75 @@ class XmlPostProcessorTest {
                                 "Hello <b>%1${'$'}s</b>"
                               </string>
                             </resources>
-                             """.trimIndent().formatXml()
+                             """.trimIndent().formatXml(true)
 
-        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString))
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString, true))
+    }
+
+    @Test
+    fun `Postprocessing XML with string HTML symbols works 2`() {
+        // Test complete Xml
+        val inputXmlString = """
+                            <resources>
+                              <string name="hello_friend_bold">
+                                "&amp;lt;b&amp;gt;Hello world&amp;lt;/b&amp;gt;"
+                              </string>
+                            </resources>
+                             """.trimIndent()
+
+        val expectedResult = """
+                            <resources>
+                              <string name="hello_friend_bold">
+                                "&lt;b&gt;Hello world&lt;/b&gt;"
+                              </string>
+                            </resources>
+                             """.trimIndent().formatXml(false)
+
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString, true))
+    }
+
+    @Test
+    fun `Postprocessing XML with string HTML symbols and unescape set to false works`() {
+        // Test complete Xml
+        val inputXmlString = """
+                            <resources>
+                              <string name="hello_friend_bold">
+                                "Hello &lt;b&gt;{{name}}&lt;/b&gt;"
+                              </string>
+                            </resources>
+                             """.trimIndent()
+
+        val expectedResult = """
+                            <resources>
+                              <string name="hello_friend_bold">
+                                "Hello &lt;b&gt;%1${'$'}s&lt;/b&gt;"
+                              </string>
+                            </resources>
+                             """.trimIndent().formatXml(false)
+
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString, false))
+    }
+
+    @Test
+    fun `Postprocessing XML with string HTML symbols and unescape set to false works 2`() {
+        // Test complete Xml
+        val inputXmlString = """
+                            <resources>
+                              <string name="hello_friend_bold">
+                                "&amp;lt;b&amp;gt;Hello world&amp;lt;/b&amp;gt;"
+                              </string>
+                            </resources>
+                             """.trimIndent()
+
+        val expectedResult = """
+                            <resources>
+                              <string name="hello_friend_bold">
+                                "&amp;lt;b&amp;gt;Hello world&amp;lt;/b&amp;gt;"
+                              </string>
+                            </resources>
+                             """.trimIndent().formatXml(false)
+
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString, false))
     }
 
     @Test
@@ -334,9 +393,9 @@ class XmlPostProcessorTest {
                                 <![CDATA[Some text<a href="%1${'$'}s">Link</a> text text]]>
                               </string>
                             </resources>
-                             """.trimIndent().formatXml()
+                             """.trimIndent().formatXml(true)
 
-        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString))
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString, true))
     }
 
     @Test
@@ -362,9 +421,9 @@ class XmlPostProcessorTest {
                                 ]]>
                               </string>
                             </resources>
-                             """.trimIndent().formatXml()
+                             """.trimIndent().formatXml(true)
 
-        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString))
+        Assert.assertEquals(expectedResult, xmlPostProcessor.formatTranslationXml(inputXmlString, true))
     }
 
     @Test
@@ -439,9 +498,9 @@ class XmlPostProcessorTest {
             xp.evaluate(xpNamePath, splitTranslationXmlMap.getValue(tabletRegexString)).trim())
     }
 
-    private fun String.formatXml(): String =
+    private fun String.formatXml(unescapeHtmlTags: Boolean): String =
         DocumentBuilderFactory.newInstance()
             .newDocumentBuilder()
             .parse(this.byteInputStream(Charsets.UTF_8))
-            .toAndroidXmlString()
+            .toAndroidXmlString(unescapeHtmlTags)
 }


### PR DESCRIPTION
### Github issue (delete if this does not apply)
Resolves #52 

### PR's key points
The PR adds a new flag to toggle HTML unescaping from strings.

<details open><summary>Groovy</summary>

```groovy
poEditor {
    apiToken = "your_api_token"
    projectId = 12345
    defaultLang = "en"
    unescapeHtmlTags = false
}
```

</details>

<details><summary>Kotlin</summary>

```kotlin
poEditor {
    apiToken = "your_api_token"
    projectId = 12345
    defaultLang = "en"
    unescapeHtmlTags = false
}
```

</details>
 
### How to review this PR?
Check that the flag works as expected.
 
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [x] Documentation added to README.md (if a new feature is added)
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
