### PR TITLE
Fix Indonesian, Hebrew and Yiddish languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .idea/**/dictionaries
 .idea/**/shelf
 .idea/**/runConfigurations.xml
+.idea/kotlinc.xml
 
 # Generated files
 .idea/**/contentModel.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No removed features!
 ### Fixed
 - Fix Chinese variants support
+- Fix Indonesian, Hebrew and Yiddish support
 ### Security
 - No security issues fixed!
 

--- a/src/test/kotlin/com/hyperdevs/poeditor/gradle/utils/LocaleUtilsTest.kt
+++ b/src/test/kotlin/com/hyperdevs/poeditor/gradle/utils/LocaleUtilsTest.kt
@@ -18,17 +18,35 @@
 
 package com.hyperdevs.poeditor.gradle.utils
 
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class LocaleUtilsTest {
     @Test
     fun `Creating values modifier from standard lang code works`() {
-        Assert.assertEquals("es", createValuesModifierFromLangCode("es"))
+        assertEquals("es", createValuesModifierFromLangCode("es"))
     }
 
     @Test
     fun `Creating values modifier from specialized lang code works`() {
-        Assert.assertEquals("es-rMX", createValuesModifierFromLangCode("es-mx"))
+        assertEquals("es-rMX", createValuesModifierFromLangCode("es-mx"))
+    }
+
+    @Test
+    fun `Creating values modifier from Chinese lang codes work`() {
+        assertEquals("zh", createValuesModifierFromLangCode("zh-CN"))
+        assertEquals("zh-rHK", createValuesModifierFromLangCode("zh-hk"))
+        assertEquals("zh-rMO", createValuesModifierFromLangCode("zh-mo"))
+        assertEquals("zh-rSG", createValuesModifierFromLangCode("zh-sg"))
+        assertEquals("b+zh+Hans", createValuesModifierFromLangCode("zh-Hans"))
+        assertEquals("b+zh+Hant", createValuesModifierFromLangCode("zh-Hant"))
+    }
+
+    @Test
+    fun `Creating values modifier from old lang codes works`() {
+        assertEquals("in", createValuesModifierFromLangCode("id"))
+        assertEquals("iw", createValuesModifierFromLangCode("he"))
+        assertEquals("iw-rIL", createValuesModifierFromLangCode("he-IL"))
+        assertEquals("ji", createValuesModifierFromLangCode("yi"))
     }
 }


### PR DESCRIPTION
### Github issue
Resolves #56 

### PR's key points
The PR fixes Indonesian, Hebrew and Yiddish languages by redirecting them to their proper Android `values` directories.
It seems to be an historic issue regarding Androd Locales, as it can be found in [Locale docs](https://developer.android.com/reference/java/util/Locale.html#Locale(java.lang.String)).
 
### How to review this PR?
Validate that languages are redirected to their proper `values` directories.

### References
- Locale documentation: https://developer.android.com/reference/java/util/Locale.html#Locale(java.lang.String)
- List of supported languages up to Android 5.1: https://stackoverflow.com/a/7989085/9288365
- List of supported languages from Android 7 to Android 9: https://stackoverflow.com/a/52329560/9288365
- Android Issue Tracker issue regarding Indonesian locale: https://issuetracker.google.com/issues/36911507
- Android Issue Tracker issue regarding Hebrew locale: https://issuetracker.google.com/issues/36908826
- Java 17 locale changes: https://bugs.openjdk.org/browse/JDK-8267069
  
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [x] Documentation added to README.md (if a new feature is added)
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
