### PR TITLE
Add support for custom resource file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added configuration support to define custom resource file names.
+- Add configuration support to define custom resource file names.
 ### Changed
 - No changed features!
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- No new features!
+- Added configuration support to define custom resource file names.
 ### Changed
 - No changed features!
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Attribute                          | Description
 ```languageValuesOverridePathMap```    | (Since 2.2.0) (Optional) Map of `language_code:path` entries that you want to override the default language values folder with. Defaults to empty map.
 ```minimumTranslationPercentage``` | (Since 2.3.0) (Optional) The minimum accepted percentage of translated strings per language. Languages with fewer translated strings will not be fetched. Defaults to no minimum, allowing all languages to be fetched.
 ```filters```                      | (Since 2.4.0) (Optional) List of PoEditor filters to use during download. Defaults to empty list. Accepted values are defined by the POEditor API.
-```resFileName``` | (Since 3.1.0) (Optional) Sets the file name for the imported string resource xml files. Defaults to `strings`
+```resFileName``` | (Since 3.1.0) (Optional) Sets the file name for the imported string resource XML files. Defaults to `strings`
 After the configuration is done, just run the new ```importPoEditorStrings``` task via Android Studio or command line:
 
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Attribute                          | Description
 ```languageValuesOverridePathMap```    | (Since 2.2.0) (Optional) Map of `language_code:path` entries that you want to override the default language values folder with. Defaults to empty map.
 ```minimumTranslationPercentage``` | (Since 2.3.0) (Optional) The minimum accepted percentage of translated strings per language. Languages with fewer translated strings will not be fetched. Defaults to no minimum, allowing all languages to be fetched.
 ```filters```                      | (Since 2.4.0) (Optional) List of PoEditor filters to use during download. Defaults to empty list. Accepted values are defined by the POEditor API.
-
+```resFileName``` | (Since 3.1.0) (Optional) Sets the file name for the imported string resource xml files. Defaults to `strings`
 After the configuration is done, just run the new ```importPoEditorStrings``` task via Android Studio or command line:
 
 ```
@@ -100,7 +100,7 @@ After the configuration is done, just run the new ```importPoEditorStrings``` ta
 This task will:
 * Download all strings files (every available lang) from PoEditor given the api token and project id.
 * Process the incoming strings to fix some PoEditor incompatibilities with Android strings system. 
-* Create and save strings.xml files to ```/values-<lang>``` (or ```/values``` in case of the default lang). It supports
+* Create and save strings.xml (or whatever file name you desire by using the `resFileName` attribute) files to ```/values-<lang>``` (or ```/values``` in case of the default lang). It supports
 region specific languages by creating the proper folders (i.e. ```/values-es-rMX```).
 
 ## Enhanced syntax

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
@@ -31,6 +31,7 @@ fun main() {
 
     val apiToken = dotenv.get("API_TOKEN", "")
     val projectId = dotenv.get("PROJECT_ID", "-1").toInt()
+    val resFileName = dotenv.get("RES_FILE_NAME", "")
     val resDirPath = dotenv.get("RES_DIR_PATH", "")
     val defaultLanguage = dotenv.get("DEFAULT_LANGUAGE", "")
     val filters = dotenv.get("FILTERS", "")
@@ -61,6 +62,7 @@ fun main() {
         filters,
         tags,
         languageValuesOverridePathMap,
-        minimumTranslationPercentage
+        minimumTranslationPercentage,
+        resFileName
     )
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
@@ -31,7 +31,7 @@ fun main() {
 
     val apiToken = dotenv.get("API_TOKEN", "")
     val projectId = dotenv.get("PROJECT_ID", "-1").toInt()
-    val resFileName = dotenv.get("RES_FILE_NAME", "")
+    val resFileName = dotenv.get("RES_FILE_NAME", "strings")
     val resDirPath = dotenv.get("RES_DIR_PATH", "")
     val defaultLanguage = dotenv.get("DEFAULT_LANGUAGE", "")
     val filters = dotenv.get("FILTERS", "")

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
@@ -56,6 +56,7 @@ class PoEditorPlugin : Plugin<Project> {
                 tags.convention(emptyList())
                 languageValuesOverridePathMap.convention(emptyMap())
                 minimumTranslationPercentage.convention(-1)
+                resFileName.convention("strings")
             }
 
         // Add flavor and build-type configurations if the project has the "com.android.application" plugin

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
@@ -79,6 +79,15 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
     val defaultResPath: Property<String> = objects.property(String::class.java)
 
     /**
+     * File name of the string resource files.
+     *
+     * Defaults to "strings" if not defined.
+     */
+    @get:Optional
+    @get:Input
+    val resFileName: Property<String> = objects.property(String::class.java)
+
+    /**
      * Filters to limit downloaded strings with, from the officially supported list in PoEditor.
      *
      * Defaults to an empty list of filters if not present.
@@ -164,6 +173,16 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
      * Gradle Kotlin DSL users must use `defaultResPath.set(value)`.
      */
     fun setDefaultResPath(value: String) = defaultResPath.set(value)
+
+    /**
+     * Sets the file name for the resource files.
+     *
+     * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
+     * https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties for more details.
+     *
+     * Gradle Kotlin DSL users must use `resFileName.set(value)`.
+     */
+    fun setResFileName(value: String) = resFileName.set(value)
 
     /**
      * Sets the filters to limit downloaded strings with, from the officially supported list in PoEditor.

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
@@ -88,7 +88,8 @@ object PoEditorStringsImporter {
                               filters: List<String>,
                               tags: List<String>,
                               languageValuesOverridePathMap: Map<String, String>,
-                              minimumTranslationPercentage: Int) {
+                              minimumTranslationPercentage: Int,
+                              resFileName: String) {
         try {
             val poEditorApiController = PoEditorApiControllerImpl(apiToken, poEditorApi)
 
@@ -139,15 +140,16 @@ object PoEditorStringsImporter {
 
                 xmlWriter.saveXml(
                     resDirPath,
+                    resFileName,
                     postProcessedXmlDocumentMap,
                     defaultLang,
                     languageCode,
-                    languageValuesOverridePathMap
+                    languageValuesOverridePathMap,
                 )
             }
         } catch (e: Exception) {
             logger.error("An error happened when retrieving strings from project. " +
-                "Please review the plug-in's input parameters and try again")
+                         "Please review the plug-in's input parameters and try again")
             throw e
         }
     }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -49,6 +49,7 @@ abstract class ImportPoEditorStringsTask
         val tags: List<String>
         val languageOverridePathMap: Map<String, String>
         val minimumTranslationPercentage: Int
+        val resFileName: String
 
         try {
             apiToken = extension.apiToken.get()
@@ -59,6 +60,7 @@ abstract class ImportPoEditorStringsTask
             tags = extension.tags.get()
             languageOverridePathMap = extension.languageValuesOverridePathMap.get()
             minimumTranslationPercentage = extension.minimumTranslationPercentage.get()
+            resFileName = extension.resFileName.get()
         } catch (e: Exception) {
             logger.error("Import configuration failed", e)
 
@@ -76,6 +78,7 @@ abstract class ImportPoEditorStringsTask
             filters,
             tags,
             languageOverridePathMap,
-            minimumTranslationPercentage)
+            minimumTranslationPercentage,
+            resFileName)
     }
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/AndroidXmlWriter.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/AndroidXmlWriter.kt
@@ -35,7 +35,9 @@ class AndroidXmlWriter {
      * Saves a given map of XML files related to a language that the project contains to the
      * project's strings folder.
      */
+    @Suppress("LongParameterList")
     fun saveXml(resDirPath: String,
+                resFileName: String,
                 postProcessedXmlDocumentMap: Map<String, Document>,
                 defaultLang: String,
                 languageCode: String,
@@ -61,13 +63,14 @@ class AndroidXmlWriter {
                 baseValuesDir
             }
         }
+        val resourceFileName = resFileName.ifEmpty { "strings" }
 
         folderToXmlMap.forEach { (valuesFolderFile, document) ->
-            saveXmlToFolder(valuesFolderFile, document)
+            saveXmlToFolder(valuesFolderFile, document, resourceFileName)
         }
     }
 
-    private fun saveXmlToFolder(stringsFolderFile: File, document: Document) {
+    private fun saveXmlToFolder(stringsFolderFile: File, document: Document, resFileName: String) {
         if (!stringsFolderFile.exists()) {
             logger.debug("Creating strings folder for new language")
             val folderCreated = stringsFolderFile.mkdirs()
@@ -76,6 +79,6 @@ class AndroidXmlWriter {
         }
 
         logger.lifecycle("Saving strings to ${stringsFolderFile.absolutePath}")
-        File(stringsFolderFile, "strings.xml").writeText(document.toAndroidXmlString())
+        File(stringsFolderFile, "$resFileName.xml").writeText(document.toAndroidXmlString())
     }
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/AndroidXmlWriter.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/AndroidXmlWriter.kt
@@ -63,10 +63,9 @@ class AndroidXmlWriter {
                 baseValuesDir
             }
         }
-        val resourceFileName = resFileName.ifEmpty { "strings" }
 
         folderToXmlMap.forEach { (valuesFolderFile, document) ->
-            saveXmlToFolder(valuesFolderFile, document, resourceFileName)
+            saveXmlToFolder(valuesFolderFile, document, resFileName)
         }
     }
 


### PR DESCRIPTION
### PR's key points
This PR makes it possible to define a custom name for the fetched string resource file, e.g. `poeditor_strings.xml`. This is useful in certain projects where you have multiple sources of strings used and PoEditor is just one of these. 

### How to review this PR?
Thoroughly, I found no good exisiting test class to add tests to for this. 
 
### Related Issues (delete if this does not apply)
 
### Definition of Done
- [X] Changes summary added to CHANGELOG.md
- [X] Documentation added to README.md (if a new feature is added)
- [ ] Tests added (if new code is added)
- [X] There is no outcommented or debug code left
