### PR TITLE
Add 'order' setter so it can be used in poEditor DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - No removed features!
 ### Fixed
-- No fixed issues!
+- Fix `order` setter not added to `PoEditorPluginExtension`
 ### Security
 - No security issues fixed!
 

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
@@ -204,6 +204,16 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
     fun setFilters(value: List<String>) = filters.set(value)
 
     /**
+     * Sets the order in which to sort the strings from the officially supported list in PoEditor.
+     *
+     * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
+     * https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties for more details.
+     *
+     * Gradle Kotlin DSL users must use `order.set(value)`.
+     */
+    fun setOrder(value: String) = order.set(value)
+
+    /**
      * Sets the tags to filter downloaded strings with, previously declared in PoEditor.
      *
      * NOTE: added for Gradle Groovy DSL compatibility. Check the note on


### PR DESCRIPTION
### Github issue (delete if this does not apply)
Resolves #61

### PR's key points
The PR adds a missing setter for the `order` property of the plug-in
 
### How to review this PR?
Just check if the setter works as expected now
  
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [x] Documentation added to README.md (if a new feature is added)
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
