### PR TITLE
Add 'unquoted' flag to unquote strings from PoEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- No new features!
+- Add option to unquote strings via export API
 ### Changed
 - No changed features!
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -79,19 +79,20 @@ poEditor {
 
 The complete attribute list is the following:
 
-Attribute                          | Description
------------------------------------|-----------------------------------------
-```apiToken```                     | PoEditor API Token.
-```projectId```                    | PoEditor project ID.
-```defaultLang```                  | (Optional) The lang to be used to build default ```strings.xml``` (```/values``` folder). Defaults to English (`en`).
-```defaultResPath```               | (Since 1.3.0) (Optional) Path where the plug-in should dump strings. Defaults to the module's default (or build variant) `res` path.
-```enabled```                      | (Since 1.4.0) (Optional) Enables the generation of the block's related task. Defaults to `true`.
-```tags```                         | (Since 2.1.0) (Optional) List of PoEditor tags to download. Defaults to empty list.
+Attribute                              | Description
+---------------------------------------|-----------------------------------------
+```apiToken```                         | PoEditor API Token.
+```projectId```                        | PoEditor project ID.
+```defaultLang```                      | (Optional) The lang to be used to build default ```strings.xml``` (```/values``` folder). Defaults to English (`en`).
+```defaultResPath```                   | (Since 1.3.0) (Optional) Path where the plug-in should dump strings. Defaults to the module's default (or build variant) `res` path.
+```enabled```                          | (Since 1.4.0) (Optional) Enables the generation of the block's related task. Defaults to `true`.
+```tags```                             | (Since 2.1.0) (Optional) List of PoEditor tags to download. Defaults to empty list.
 ```languageValuesOverridePathMap```    | (Since 2.2.0) (Optional) Map of `language_code:path` entries that you want to override the default language values folder with. Defaults to empty map.
-```minimumTranslationPercentage``` | (Since 2.3.0) (Optional) The minimum accepted percentage of translated strings per language. Languages with fewer translated strings will not be fetched. Defaults to no minimum, allowing all languages to be fetched.
-```filters```                      | (Since 2.4.0) (Optional) List of PoEditor filters to use during download. Defaults to empty list. Accepted values are defined by the POEditor API.
-```resFileName``` | (Since 3.1.0) (Optional) Sets the file name for the imported string resource XML files. Defaults to `strings`.
-```order```                        | (Since 3.1.0) (Optional) Defines how to order the export. Accepted values are defined by the POEditor API.
+```minimumTranslationPercentage```     | (Since 2.3.0) (Optional) The minimum accepted percentage of translated strings per language. Languages with fewer translated strings will not be fetched. Defaults to no minimum, allowing all languages to be fetched.
+```filters```                          | (Since 2.4.0) (Optional) List of PoEditor filters to use during download. Defaults to empty list. Accepted values are defined by the POEditor API.
+```resFileName```                      | (Since 3.1.0) (Optional) Sets the file name for the imported string resource XML files. Defaults to `strings`.
+```order```                            | (Since 3.1.0) (Optional) Defines how to order the export. Accepted values are defined by the POEditor API.
+```unquoted```                         | (Since 3.2.0) (Optional) Defines if the strings should be unquoted, overriding default PoEditor configuration. Defaults to `false`.
 
 After the configuration is done, just run the new ```importPoEditorStrings``` task via Android Studio or command line:
 

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
@@ -57,6 +57,7 @@ fun main() {
         }
         ?: emptyMap()
     val minimumTranslationPercentage = dotenv.get("MINIMUM_TRANSLATION_PERCENTAGE", "85").toInt()
+    val unquoted = dotenv.get("UNQUOTED", "false").toBoolean()
 
     PoEditorStringsImporter.importPoEditorStrings(
         apiToken,
@@ -68,6 +69,7 @@ fun main() {
         tags,
         languageValuesOverridePathMap,
         minimumTranslationPercentage,
-        resFileName
+        resFileName,
+        unquoted
     )
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
@@ -59,6 +59,7 @@ class PoEditorPlugin : Plugin<Project> {
                 languageValuesOverridePathMap.convention(emptyMap())
                 minimumTranslationPercentage.convention(-1)
                 resFileName.convention("strings")
+                unquoted.convention(false)
             }
 
         // Add flavor and build-type configurations if the project has the "com.android.application" plugin

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
@@ -134,6 +134,15 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
     val minimumTranslationPercentage: Property<Int> = objects.property(Int::class.java)
 
     /**
+     * Defines if the output strings exported from PoEditor should be unquoted.
+     *
+     * Defaults to "false" meaning that all texts will be quoted.
+     */
+    @get:Optional
+    @get:Input
+    val unquoted: Property<Boolean> = objects.property(Boolean::class.java)
+
+    /**
      * Sets the configuration as enabled or not.
      *
      * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
@@ -242,4 +251,14 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
      * Gradle Kotlin DSL users must use `minimumTranslationPercentage.set(value)`.
      */
     fun setMinimumTranslationPercentage(value: Int) = minimumTranslationPercentage.set(value)
+
+    /**
+     * Sets if the exported strings should be unquoted or not.
+     *
+     * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
+     * https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties for more details.
+     *
+     * Gradle Kotlin DSL users must use `unquoted.set(value)`.
+     */
+    fun setUnquoted(value: Boolean) = unquoted.set(value)
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
@@ -92,9 +92,10 @@ object PoEditorStringsImporter {
                               tags: List<String>,
                               languageValuesOverridePathMap: Map<String, String>,
                               minimumTranslationPercentage: Int,
-                              resFileName: String) {
+                              resFileName: String,
+                              unquoted: Boolean) {
         try {
-            val poEditorApiController = PoEditorApiControllerImpl(apiToken, poEditorApi)
+            val poEditorApiController = PoEditorApiControllerImpl(apiToken, moshi, poEditorApi)
 
             // Retrieve available languages from PoEditor
             logger.lifecycle("Retrieving project languages...")
@@ -131,7 +132,9 @@ object PoEditorStringsImporter {
                     type = ExportType.ANDROID_STRINGS,
                     filters = filters,
                     order = order,
-                    tags = tags)
+                    tags = tags,
+                    unquoted = unquoted
+                )
 
                 // Download translation File to in-memory string
                 logger.lifecycle("Downloading file from URL: $translationFileUrl")

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/api/PoEditorApi.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/api/PoEditorApi.kt
@@ -50,5 +50,5 @@ interface PoEditorApi {
                           @Field("filters") filters: List<String>? = null,
                           @Field("order") order: String? = null,
                           @Field("tags") tags: List<String>? = null,
-                          @Field("options") options: Map<String, String>? = null): Call<ExportResponse>
+                          @Field("options") options: String? = null): Call<ExportResponse>
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/api/PoEditorApiModels.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/api/PoEditorApiModels.kt
@@ -148,3 +148,12 @@ enum class OrderType {
             }
     }
 }
+
+/**
+ * Object passed as export options.
+ */
+data class Options(val unquoted: Int) {
+    init {
+        require(unquoted in 0..1) { "unquoted value must be 0 or 1" }
+    }
+}

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -53,6 +53,7 @@ abstract class ImportPoEditorStringsTask
         val languageOverridePathMap: Map<String, String>
         val minimumTranslationPercentage: Int
         val resFileName: String
+        val unquoted: Boolean
 
         try {
             apiToken = extension.apiToken.get()
@@ -65,6 +66,7 @@ abstract class ImportPoEditorStringsTask
             languageOverridePathMap = extension.languageValuesOverridePathMap.get()
             minimumTranslationPercentage = extension.minimumTranslationPercentage.get()
             resFileName = extension.resFileName.get()
+            unquoted = extension.unquoted.get()
         } catch (e: Exception) {
             logger.error("Import configuration failed", e)
 
@@ -84,6 +86,7 @@ abstract class ImportPoEditorStringsTask
             tags,
             languageOverridePathMap,
             minimumTranslationPercentage,
-            resFileName)
+            resFileName,
+            unquoted)
     }
 }


### PR DESCRIPTION
### PR's key points
The PR adds the `unquoted` flag to the PoEditor options so users can download strings without quotes from PoEditor.
This feature comes from a question in #61.
 
### How to review this PR?
Check that the flag works as expected.
 
### Notes
More information here: https://poeditor.com/kb/quotes-in-android-string-resources
 
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [x] Documentation added to README.md (if a new feature is added)
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
