### PR TITLE
Response parse error has been fixed.

### DIFF
--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/PoEditorApiController.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/PoEditorApiController.kt
@@ -61,7 +61,7 @@ class PoEditorApiControllerImpl(private val apiToken: String,
         val response = poEditorApi.getProjectLanguages(
             apiToken = apiToken,
             id = projectId).execute()
-        return response.onSuccessful { it.result.languages }
+        return response.onSuccessful { it.result?.languages ?: emptyList() }
     }
 
     @Suppress("LongParameterList")

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/api/PoEditorApiModels.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/api/PoEditorApiModels.kt
@@ -37,7 +37,7 @@ data class ResponseStatus(val status: String,
  * PoEditor response to "list languages" call.
  */
 data class ListLanguagesResponse(override val response: ResponseStatus,
-                                 val result: ListLanguagesResult) : PoEditorResponse(response)
+                                 val result: ListLanguagesResult?) : PoEditorResponse(response)
 
 /**
  * Result of a "list language" call.


### PR DESCRIPTION
### Github issue (delete if this does not apply)
There is no issue for this bug.

### PR's key points
When the PoEditor API response does not contain a **result**  field then the JSON parser throws an exception (_com.squareup.moshi.JsonDataException: Required value 'result' missing at $_).

For example: when gets the project languages (getProjectLanguages) and the API token is valid but does not have a permission for the PoEditor project then the API response this:
```
POST https://api.poeditor.com/v2/languages/list
{
	"response": {
		"status": "fail",
		"code": "403",
		"message": "You don't have permission to access this resource"
	}
}
```
It does not contain a **result** field and the JSON parser throws an exception (JsonDataException). It can't reach the **onSuccessful** (_PoEditorApiControllerImpl_) method which would throw an **IllegalStateException** with the detailed error message.
 
### How to review this PR?
Check if the responses handled correctly.

