### PR TITLE
Fix parsing more than 9 placeholders with order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - No security issues fixed!
 
+## [3.4.1] - 2023-07-13
+### Fixed
+- Fix parsing of texts with more than 9 placeholders.
+
 ## [3.4.0] - 2023-05-08
 ### Added
 - Add new `unescapeHtmlTags` flag to enable or disable HTML unescaping from strings.
@@ -470,7 +474,8 @@ res_dir_path -> resDirPath
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/3.4.0...HEAD
+[Unreleased]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/3.4.1...HEAD
+[3.4.1]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/3.4.0...3.4.1
 [3.4.0]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/3.3.0...3.4.0
 [3.3.1]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/3.3.0...3.3.1
 [3.3.0]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/3.2.0...3.3.0

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/XmlPostProcessor.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/XmlPostProcessor.kt
@@ -20,7 +20,6 @@ package com.hyperdevs.poeditor.gradle.xml
 
 import com.hyperdevs.poeditor.gradle.ktx.toAndroidXmlString
 import com.hyperdevs.poeditor.gradle.ktx.toStringsXmlDocument
-import com.hyperdevs.poeditor.gradle.ktx.unescapeHtmlTags
 import com.hyperdevs.poeditor.gradle.utils.ALL_REGEX_STRING
 import org.w3c.dom.*
 
@@ -31,7 +30,7 @@ import org.w3c.dom.*
 class XmlPostProcessor {
     companion object {
         private val DEFAULT_ENCODING = Charsets.UTF_8
-        private val VARIABLE_REGEX = Regex("""\{\d?\{(.*?)\}\}""")
+        private val VARIABLE_REGEX = Regex("""\{(\d*)\{(.*?)\}\}""")
 
         private const val TAG_RESOURCES = "resources"
         private const val TAG_STRING = "string"
@@ -82,9 +81,10 @@ class XmlPostProcessor {
             //  throw an exception
 
             // If the placeholder contains an ordinal, use it: {2{pages_count}} -> %2$s
-            val match = matchResult.groupValues[0]
-            if (Character.isDigit(match[1])) {
-                "%${match[1]}\$s"
+            val fullMatch = matchResult.groupValues[0]
+            val placeholderVaraibleOrder = matchResult.groupValues[1]
+            if (placeholderVaraibleOrder.toIntOrNull() != null) {
+                "%$placeholderVaraibleOrder\$s"
             } else { // If not, use "1" as the ordinal: {{pages_count}} -> %1$s
                 "%1\$s"
             }

--- a/src/test/kotlin/com/hyperdevs/poeditor/gradle/xml/XmlPostProcessorTest.kt
+++ b/src/test/kotlin/com/hyperdevs/poeditor/gradle/xml/XmlPostProcessorTest.kt
@@ -88,6 +88,13 @@ class XmlPostProcessorTest {
             xmlPostProcessor.formatTranslationString("Hello {{name}}. How are you {{name}}?"))
         Assert.assertEquals("Hello %1\$s. This is your score: %2\$s",
             xmlPostProcessor.formatTranslationString("Hello {1{name}}. This is your score: {2{score}}"))
+
+        Assert.assertEquals("Hello %1\$s %2\$s %3\$s %4\$s %5\$s %6\$s %7\$s %8\$s %9\$s %10\$s %11\$s",
+            xmlPostProcessor.formatTranslationString(
+                "Hello {1{name}} {2{name}} {3{name}} {4{name}} {5{name}} " +
+                "{6{name}} {7{name}} {8{name}} {9{name}} {10{name}} {11{name}}"
+            )
+        )
     }
 
     @Test


### PR DESCRIPTION
### PR's key points
Fix parsing of placeholders when more than 9 placeholders are present.
 
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [x] Documentation added to README.md (if a new feature is added)
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
