### PR TITLE
Send tags as String JSON array instead of list of form URL encoded args

### DIFF
--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/PoEditorApiController.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/PoEditorApiController.kt
@@ -57,6 +57,9 @@ class PoEditorApiControllerImpl(private val apiToken: String,
     private val optionsAdapter: JsonAdapter<List<Options>> =
         moshi.adapter(Types.newParameterizedType(List::class.java, Options::class.java))
 
+    private val tagsAdapter: JsonAdapter<List<String>> =
+        moshi.adapter(Types.newParameterizedType(List::class.java, String::class.java))
+
     override fun getProjectLanguages(projectId: Int): List<ProjectLanguage> {
         val response = poEditorApi.getProjectLanguages(
             apiToken = apiToken,
@@ -85,7 +88,7 @@ class PoEditorApiControllerImpl(private val apiToken: String,
             filters = filters?.map { it.name.toLowerCase() },
             language = code,
             order = order.name.toLowerCase(),
-            tags = tags,
+            tags = tagsAdapter.toJson(tags),
             options = options
         ).execute()
 

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/api/PoEditorApi.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/api/PoEditorApi.kt
@@ -49,6 +49,6 @@ interface PoEditorApi {
                           @Field("type") type: String,
                           @Field("filters") filters: List<String>? = null,
                           @Field("order") order: String? = null,
-                          @Field("tags") tags: List<String>? = null,
+                          @Field("tags") tags: String? = null,
                           @Field("options") options: String? = null): Call<PoEditorResponse<ExportResult>>
 }


### PR DESCRIPTION
### Github issue (delete if this does not apply)
Resolves #69

### PR's key points
Use Moshi to serialize the list of tags to a JSON array before sending to Poeditor API
 
### How to review this PR?
Just check code style and testing
 
### Definition of Done
- [ ] Changes summary added to CHANGELOG.md
- [ ] Documentation added to README.md (if a new feature is added)
- [ ] Tests added (if new code is added)
- [ ] There is no outcommented or debug code left
