### PR TITLE
Add lazy property configuration

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="17">
+      <module name="poeditor-android-gradle-plugin.plugin" target="17" />
+      <module name="poeditor-android-gradle-plugin.plugin.main" target="17" />
+      <module name="poeditor-android-gradle-plugin.plugin.test" target="17" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - No security issues fixed!
 
+## [4.1.0] - 2023-11-26
+### Changed
+- Allow PoEditor importing task lazy configuration.
+
 ## [4.0.0] - 2023-11-07
 ### Changed
 - BREAKING CHANGE: Bump Gradle version to 8 and AGP version to 8.1.2.
@@ -483,7 +487,8 @@ res_dir_path -> resDirPath
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/4.0.0...HEAD
+[Unreleased]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/4.1.0...HEAD
+[4.1.0]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/4.0.0...4.1.0
 [4.0.0]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/3.4.2...4.0.0
 [3.4.2]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/3.4.1...3.4.2
 [3.4.1]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/3.4.0...3.4.1

--- a/README.md
+++ b/README.md
@@ -579,6 +579,25 @@ poEditor {
 
 </details>
 
+## Creating extra PoEditor tasks
+> Requires version 4.1.0 of the plug-in
+
+You can create extra PoEditor tasks to import strings for other projects, for example. You can do so by adding this to
+your `build.gradle(.kts)` file:
+<details><summary>Kotlin</summary>
+
+```kotlin
+tasks.register("importCustomPoEditorStrings", ImportPoEditorStringsTask::class.java) {
+    description = "Imports custom strings from POEditor."
+    group = "strings"
+
+    apiToken = "another_token_from_a_different_project"
+    projectId = 12345
+    resFileName = "strings_custom"
+}
+```
+
+</details>
 
 ## iOS alternative
 If you want a similar solution for your iOS projects, check this out: [poeditor-parser-swift](https://github.com/hyperdevs-team/poeditor-parser-swift)

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
@@ -38,6 +38,15 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
     override fun getName(): String = name
 
     /**
+     * Name of the configuration to use to save strings.
+     *
+     * Must be present in order to run the plugin. Configured internally
+     */
+    @get:Optional
+    @get:Input
+    internal val configName: Property<String> = objects.property(String::class.java)
+
+    /**
      * Whether the configuration is enabled or not.
      */
     @get:Optional
@@ -143,7 +152,7 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
     val unquoted: Property<Boolean> = objects.property(Boolean::class.java)
 
     /**
-     * Whether or not HTML tags in strings should be unescaped or not.
+     * Whether HTML tags in strings should be unescaped or not.
      *
      * Defaults to true.
      */


### PR DESCRIPTION
### PR's key points
Adds lazy configuration parameters to the main PoEditor import task. This is useful to declare new tasks based on the main import task, as specified in the README file.
 
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [x] Documentation added to README.md (if a new feature is added)
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
