### PR TITLE
Restore conventions for uninitialized properties and fix flavor-specific configs not picking up the default resource path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - No security issues fixed!
 
+## [4.1.1] - 2023-12-11
+### Fixed
+- Restore conventions for uninitialized properties
+- Fix flavor-specific configs not picking up the default resource path for the brand
+
 ## [4.1.0] - 2023-11-26
 ### Changed
 - Allow PoEditor importing task lazy configuration.
@@ -487,7 +492,8 @@ res_dir_path -> resDirPath
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/4.1.0...HEAD
+[Unreleased]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/4.1.1...HEAD
+[4.1.1]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/4.1.0...4.1.1
 [4.1.0]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/4.0.0...4.1.0
 [4.0.0]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/3.4.2...4.0.0
 [3.4.2]: https://github.com/hyperdevs-team/poeditor-android-gradle-plugin/compare/3.4.1...3.4.2

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This plug-in super-charges your Android project by providing tasks to download y
 It also provides a built-in syntax to handle placeholders to enhance the already awesome Android support from PoEditor.
 
 ## Minimum requirements
+* Gradle 8.2 or above
 * Android Gradle Plug-in 8.0 or above
 
 ## Setting Up

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/DefaultValues.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/DefaultValues.kt
@@ -24,16 +24,17 @@ import java.io.File
  */
 @Suppress("MayBeConst", "MayBeConstant")
 object DefaultValues {
-    val ENABLED = true
-    val DEFAULT_LANG = "en"
-    val FILTERS = emptyList<String>()
-    val ORDER_TYPE = OrderType.NONE.name.lowercase()
-    val TAGS = emptyList<String>()
-    val LANGUAGE_VALUES_OVERRIDE_PATH_MAP = emptyMap<String, String>()
-    val MINIMUM_TRANSLATION_PERCENTAGE = -1
-    val RES_FILE_NAME = "string"
-    val UNQUOTED = false
-    val UNESCAPE_HTML_TAGS = true
+    internal val ENABLED = true
+    internal val MAIN_CONFIG_NAME: ConfigName = "main"
+    internal val DEFAULT_LANG = "en"
+    internal val FILTERS = emptyList<String>()
+    internal val ORDER_TYPE = OrderType.NONE.name.lowercase()
+    internal val TAGS = emptyList<String>()
+    internal val LANGUAGE_VALUES_OVERRIDE_PATH_MAP = emptyMap<String, String>()
+    internal val MINIMUM_TRANSLATION_PERCENTAGE = -1
+    internal val RES_FILE_NAME = "string"
+    internal val UNQUOTED = false
+    internal val UNESCAPE_HTML_TAGS = true
 
     /**
      * Apply the default convention to a [PoEditorPluginExtension].

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/DefaultValues.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/DefaultValues.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 HyperDevs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hyperdevs.poeditor.gradle
+
+import com.hyperdevs.poeditor.gradle.network.api.OrderType
+import java.io.File
+
+/**
+ * Object that holds default and convention values for the plugin properties.
+ */
+@Suppress("MayBeConst", "MayBeConstant")
+object DefaultValues {
+    val ENABLED = true
+    val DEFAULT_LANG = "en"
+    val FILTERS = emptyList<String>()
+    val ORDER_TYPE = OrderType.NONE.name.lowercase()
+    val TAGS = emptyList<String>()
+    val LANGUAGE_VALUES_OVERRIDE_PATH_MAP = emptyMap<String, String>()
+    val MINIMUM_TRANSLATION_PERCENTAGE = -1
+    val RES_FILE_NAME = "string"
+    val UNQUOTED = false
+    val UNESCAPE_HTML_TAGS = true
+
+    /**
+     * Apply the default convention to a [PoEditorPluginExtension].
+     */
+    fun applyDefaultConvention(extension: PoEditorPluginExtension, resourceDirectory: File) {
+        with(extension) {
+            enabled.convention(ENABLED)
+            defaultResPath.convention(resourceDirectory.absolutePath)
+            defaultLang.convention(DEFAULT_LANG)
+            filters.convention(FILTERS)
+            order.convention(ORDER_TYPE)
+            tags.convention(TAGS)
+            languageValuesOverridePathMap.convention(LANGUAGE_VALUES_OVERRIDE_PATH_MAP)
+            minimumTranslationPercentage.convention(MINIMUM_TRANSLATION_PERCENTAGE)
+            resFileName.convention(RES_FILE_NAME)
+            unquoted.convention(UNQUOTED)
+            unescapeHtmlTags.convention(UNESCAPE_HTML_TAGS)
+        }
+    }
+}

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
@@ -42,7 +42,7 @@ typealias ConfigName = String
  */
 class PoEditorPlugin : Plugin<Project> {
     override fun apply(project: Project) {
-        val mainConfigName = "main"
+        val mainConfigName = DefaultValues.MAIN_CONFIG_NAME
         val mainResourceDirectory = getResourceDirectory(project, mainConfigName)
 
         // Add the 'poEditorPlugin' extension object in the project,
@@ -89,7 +89,9 @@ class PoEditorPlugin : Plugin<Project> {
 
         // Add tasks for every flavor or build type
         androidComponentsExtension.beforeVariants {
+            // Add main extension since we have the main extension evaluated here
             addMainPoEditorTask(project, mainExtension)
+
             val configs = getConfigs(it.productFlavors.map { it.second }, it.buildType)
 
             generatePoEditorTasks(configs,
@@ -173,7 +175,7 @@ class PoEditorPlugin : Plugin<Project> {
                     mainPoEditorTaskDescription,
                     PLUGIN_GROUP
                 ) {
-                    configureTask("main", mainPoEditorExtension)
+                    configureTask(mainPoEditorExtension)
                 }
             }
         }
@@ -196,7 +198,8 @@ class PoEditorPlugin : Plugin<Project> {
             project.tasks.findByName(configTaskName) ?: run {
                 val rawConfigExtension = configsExtensionContainer.findByName(configName)?.also {
                     // Don't forget to add the default resources path for the configuration
-                    it.configName = configName
+                    val configResDir = getResourceDirectory(project, configName)
+                    it.defaultResPath.convention(configResDir.absolutePath)
                 }
 
                 if (rawConfigExtension != null) {
@@ -214,7 +217,7 @@ class PoEditorPlugin : Plugin<Project> {
                             getPoEditorDescriptionForConfig(configName),
                             PLUGIN_GROUP
                         ) {
-                            configureTask(configName, mergedConfigExtension)
+                            configureTask(mergedConfigExtension)
                         }
 
                         configPoEditorTaskProvidersMap.put(configName, newConfigPoEditorTask)

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPlugin.kt
@@ -43,11 +43,14 @@ typealias ConfigName = String
 class PoEditorPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val mainConfigName = "main"
+        val mainResourceDirectory = getResourceDirectory(project, mainConfigName)
 
         // Add the 'poEditorPlugin' extension object in the project,
         // used to pass parameters to the main PoEditor task
         val mainPoEditorExtension: PoEditorPluginExtension = project.extensions
-            .create<PoEditorPluginExtension>(DEFAULT_PLUGIN_NAME, project.objects, mainConfigName)
+            .create<PoEditorPluginExtension>(DEFAULT_PLUGIN_NAME, project.objects, mainConfigName).apply {
+                DefaultValues.applyDefaultConvention(this, mainResourceDirectory)
+            }
 
         // Add flavor and build-type configurations if the project has the "com.android.application" plugin
         project.plugins.withType<AppPlugin> {

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
@@ -38,15 +38,6 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
     override fun getName(): String = name
 
     /**
-     * Name of the configuration to use to save strings.
-     *
-     * Must be present in order to run the plugin. Configured internally
-     */
-    @get:Optional
-    @get:Input
-    internal val configName: Property<String> = objects.property(String::class.java)
-
-    /**
      * Whether the configuration is enabled or not.
      */
     @get:Optional

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -20,12 +20,14 @@
 package com.hyperdevs.poeditor.gradle.tasks
 
 import com.hyperdevs.poeditor.gradle.ConfigName
+import com.hyperdevs.poeditor.gradle.DefaultValues
 import com.hyperdevs.poeditor.gradle.PoEditorPluginExtension
 import com.hyperdevs.poeditor.gradle.PoEditorStringsImporter
 import com.hyperdevs.poeditor.gradle.network.api.FilterType
 import com.hyperdevs.poeditor.gradle.network.api.OrderType
 import com.hyperdevs.poeditor.gradle.utils.DEFAULT_PLUGIN_NAME
 import com.hyperdevs.poeditor.gradle.utils.POEDITOR_CONFIG_NAME
+import com.hyperdevs.poeditor.gradle.utils.getResourceDirectory
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
@@ -181,22 +183,22 @@ abstract class ImportPoEditorStringsTask @Inject constructor() : DefaultTask() {
                 "Please review the input parameters of both blocks and try again.")
         }
 
-        val conventionDefaultResPath = getResourceDirectory(project, configName.getOrElse("main"))
-            .asFile.absolutePath
+        val conventionDefaultResPath =
+            getResourceDirectory(project, configName.getOrElse("main")).absolutePath
 
         PoEditorStringsImporter.importPoEditorStrings(
             apiToken,
             projectId,
-            defaultLang.getOrElse("en"),
+            defaultLang.getOrElse(DefaultValues.DEFAULT_LANG),
             defaultResPath.getOrElse(conventionDefaultResPath),
-            filters.getOrElse(emptyList()).map { FilterType.from(it) },
-            OrderType.from(order.getOrElse(OrderType.NONE.name.lowercase())),
-            tags.getOrElse(emptyList()),
-            languageValuesOverridePathMap.getOrElse(emptyMap()),
-            minimumTranslationPercentage.getOrElse(-1),
-            resFileName.getOrElse("strings"),
-            unquoted.getOrElse(false),
-            unescapeHtmlTags.getOrElse(true)
+            filters.getOrElse(DefaultValues.FILTERS).map { FilterType.from(it) },
+            OrderType.from(order.getOrElse(DefaultValues.ORDER_TYPE.lowercase())),
+            tags.getOrElse(DefaultValues.TAGS),
+            languageValuesOverridePathMap.getOrElse(DefaultValues.LANGUAGE_VALUES_OVERRIDE_PATH_MAP),
+            minimumTranslationPercentage.getOrElse(DefaultValues.MINIMUM_TRANSLATION_PERCENTAGE),
+            resFileName.getOrElse(DefaultValues.RES_FILE_NAME),
+            unquoted.getOrElse(DefaultValues.UNQUOTED),
+            unescapeHtmlTags.getOrElse(DefaultValues.UNESCAPE_HTML_TAGS)
         )
     }
 
@@ -215,7 +217,4 @@ abstract class ImportPoEditorStringsTask @Inject constructor() : DefaultTask() {
         this.unquoted = extension.unquoted
         this.unescapeHtmlTags = extension.unescapeHtmlTags
     }
-
-    private fun getResourceDirectory(project: Project, configName: ConfigName) =
-        project.layout.projectDirectory.dir("src/$configName/res")
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -19,7 +19,6 @@
 
 package com.hyperdevs.poeditor.gradle.tasks
 
-import com.hyperdevs.poeditor.gradle.ConfigName
 import com.hyperdevs.poeditor.gradle.DefaultValues
 import com.hyperdevs.poeditor.gradle.PoEditorPluginExtension
 import com.hyperdevs.poeditor.gradle.PoEditorStringsImporter
@@ -29,7 +28,6 @@ import com.hyperdevs.poeditor.gradle.utils.DEFAULT_PLUGIN_NAME
 import com.hyperdevs.poeditor.gradle.utils.POEDITOR_CONFIG_NAME
 import com.hyperdevs.poeditor.gradle.utils.getResourceDirectory
 import org.gradle.api.DefaultTask
-import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
@@ -46,15 +44,6 @@ import javax.inject.Inject
  * 3. Creates and saves two strings.xml files to values-<lang> and values-<lang>-sw600dp (tablet specific strings)
  */
 abstract class ImportPoEditorStringsTask @Inject constructor() : DefaultTask() {
-    /**
-     * Name of the configuration to use to save strings.
-     *
-     * Must be present in order to run the plugin. Configured internally
-     */
-    @get:Optional
-    @get:Input
-    internal abstract val configName: Property<String>
-
     /**
      * PoEditor API token.
      *
@@ -183,14 +172,11 @@ abstract class ImportPoEditorStringsTask @Inject constructor() : DefaultTask() {
                 "Please review the input parameters of both blocks and try again.")
         }
 
-        val conventionDefaultResPath =
-            getResourceDirectory(project, configName.getOrElse("main")).absolutePath
-
         PoEditorStringsImporter.importPoEditorStrings(
             apiToken,
             projectId,
             defaultLang.getOrElse(DefaultValues.DEFAULT_LANG),
-            defaultResPath.getOrElse(conventionDefaultResPath),
+            defaultResPath.getOrElse(getResourceDirectory(project, DefaultValues.MAIN_CONFIG_NAME).absolutePath),
             filters.getOrElse(DefaultValues.FILTERS).map { FilterType.from(it) },
             OrderType.from(order.getOrElse(DefaultValues.ORDER_TYPE.lowercase())),
             tags.getOrElse(DefaultValues.TAGS),
@@ -202,8 +188,7 @@ abstract class ImportPoEditorStringsTask @Inject constructor() : DefaultTask() {
         )
     }
 
-    internal fun configureTask(configName: ConfigName, extension: PoEditorPluginExtension) {
-        this.configName = configName
+    internal fun configureTask(extension: PoEditorPluginExtension) {
         this.apiToken = extension.apiToken
         this.projectId = extension.projectId
         this.defaultLang = extension.defaultLang

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/utils/ProjectUtils.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/utils/ProjectUtils.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 HyperDevs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hyperdevs.poeditor.gradle.utils
+
+import com.hyperdevs.poeditor.gradle.ConfigName
+import org.gradle.api.Project
+import java.io.File
+
+/**
+ * Gets the resource directory for a given config name.
+ */
+fun getResourceDirectory(project: Project, configName: ConfigName) =
+    File(File(File(project.layout.projectDirectory.asFile, "src"), configName), "res")


### PR DESCRIPTION
### Github issue (delete if this does not apply)
Resolves #72

### PR's key points
The PR fixes several issues after the 4.1.0 update, specifically:
* Fix some uninitialized variables' errors, as specified in #72 
* Clarifies some of the README requirements so users don't have issues with the plug-in
* Fix flavor-specific configs not picking up the default resource path which got broken after changing to lazy initialization
 
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [x] Documentation added to README.md (if a new feature is added)
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
