### PR TITLE
Replace `toLowerCase` with `lowercase` to prevent locale-specific issues (e.g., Turkish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - No removed features!
 ### Fixed
-- No fixed issues!
+- Fixed the issue with toLowerCase behavior for the Turkish language 
 ### Security
 - No security issues fixed!
 

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/PoEditorApiController.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/network/PoEditorApiController.kt
@@ -84,10 +84,10 @@ class PoEditorApiControllerImpl(private val apiToken: String,
         val response = poEditorApi.getExportFileInfo(
             apiToken = apiToken,
             id = projectId,
-            type = type.toString().toLowerCase(),
-            filters = filters?.map { it.name.toLowerCase() },
+            type = type.toString().lowercase(),
+            filters = filters?.map { it.name.lowercase() },
             language = code,
-            order = order.name.toLowerCase(),
+            order = order.name.lowercase(),
             tags = tagsAdapter.toJson(tags),
             options = options
         ).execute()


### PR DESCRIPTION
### PR's key points
When using toLowerCase on the ANDROID_STRINGS string, the Turkish locale caused it to convert as androıd_strıngs (with a dotless “ı”). To prevent this issue, the string conversion was modified to explicitly specify a locale (e.g., Locale.ENGLISH), ensuring consistent behavior across different locales.

To more information => https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.text/lowercase.html
 
### How to review this PR?
 
### Related Issues (delete if this does not apply)
 
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [ ] Documentation added to README.md (if a new feature is added)
- [ ] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
