### PR TITLE
Add `includeComments` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- No new features!
+- Add new `includeComments` flag to keep comments generated in PoEditor in the generated XML files.
+<details open><summary>Groovy</summary>
+
+```groovy
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    includeComments = true
+}
+```
+
+</details>
+
+<details><summary>Kotlin</summary>
+
+```kotlin
+poEditor {
+    apiToken = "your_api_token"
+    projectId = 12345
+    defaultLang = "en"
+    includeComments = true
+}
+```
+
+</details>
 ### Changed
 - Refactor the whole parsing logic to better handle input and improve performance.
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ Attribute                              | Description
 ```resFileName```                      | (Since 3.1.0) (Optional) Sets the file name for the imported string resource XML files. Defaults to `strings`.
 ```order```                            | (Since 3.1.0) (Optional) Defines how to order the export. Accepted values are defined by the POEditor API.
 ```unquoted```                         | (Since 3.2.0) (Optional) Defines if the strings should be unquoted, overriding default PoEditor configuration. Defaults to `false`.
-```unescapeHtmlTags```                 | (Since 3.4.0) (Optional) Whether or not to unescape HTML entitites from strings. Defaults to true.
-```untranslatableStringsRegex```       | (Since 4.2.0) (Optional) Pattern to use to mark strings as translatable=false in the strings file. Defaults to null.
+```unescapeHtmlTags```                 | (Since 3.4.0) (Optional) Whether or not to unescape HTML entitites from strings. Defaults to `true`.
+```untranslatableStringsRegex```       | (Since 4.2.0) (Optional) Pattern to use to mark strings as translatable=false in the strings file. Defaults to `null`.
+```includeComments```                  | (Since 5.0.0) (Optional) Whether to include comments from the downloaded strings. Defaults to `true`.
 
 After the configuration is done, just run the new ```importPoEditorStrings``` task via Android Studio or command line:
 

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/DefaultValues.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/DefaultValues.kt
@@ -35,6 +35,7 @@ object DefaultValues {
     internal val RES_FILE_NAME = "strings"
     internal val UNQUOTED = false
     internal val UNESCAPE_HTML_TAGS = true
+    internal val INCLUDE_COMMENTS = true
 
     /**
      * Apply the default convention to a [PoEditorPluginExtension].
@@ -52,6 +53,7 @@ object DefaultValues {
             resFileName.convention(RES_FILE_NAME)
             unquoted.convention(UNQUOTED)
             unescapeHtmlTags.convention(UNESCAPE_HTML_TAGS)
+            includeComments.convention(INCLUDE_COMMENTS)
         }
     }
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/Main.kt
@@ -60,6 +60,7 @@ fun main() {
     val unquoted = dotenv.get("UNQUOTED", "false").toBoolean()
     val unescapeHtmlTags = dotenv.get("UNESCAPE_HTML_TAGS", "true").toBoolean()
     val untranslatableStringsRegex = dotenv.get("UNTRANSLATABLE_STRINGS_REGEX", null)
+    val includeComments = dotenv.get("INCLUDE_COMMENTS", "true").toBoolean()
 
     PoEditorStringsImporter.importPoEditorStrings(
         apiToken,
@@ -74,6 +75,7 @@ fun main() {
         resFileName,
         unquoted,
         unescapeHtmlTags,
-        untranslatableStringsRegex
+        untranslatableStringsRegex,
+        includeComments
     )
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorPluginExtension.kt
@@ -161,6 +161,15 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
     val untranslatableStringsRegex: Property<String?> = objects.property(String::class.java)
 
     /**
+     * Whether to include comments from the downloaded strings.
+     *
+     * Defaults to true.
+     */
+    @get:Optional
+    @get:Input
+    val includeComments: Property<Boolean> = objects.property(Boolean::class.java)
+
+    /**
      * Sets the configuration as enabled or not.
      *
      * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
@@ -299,4 +308,14 @@ open class PoEditorPluginExtension @Inject constructor(objects: ObjectFactory, p
      * Gradle Kotlin DSL users must use `setUntranslatableStringsRegex.set(value)`.
      */
     fun setUntranslatableStringsRegex(value: String) = untranslatableStringsRegex.set(value)
+
+    /**
+     * Sets if comments from the downloaded strings should be included in the output strings file.
+     *
+     * NOTE: added for Gradle Groovy DSL compatibility. Check the note on
+     * https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties for more details.
+     *
+     * Gradle Kotlin DSL users must use `includeComments.set(value)`.
+     */
+    fun setIncludeComments(value: Boolean) = includeComments.set(value)
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/PoEditorStringsImporter.kt
@@ -95,7 +95,8 @@ object PoEditorStringsImporter {
         resFileName: String,
         unquoted: Boolean,
         unescapeHtmlTags: Boolean,
-        untranslatableStringsRegex: String?
+        untranslatableStringsRegex: String?,
+        includeComments: Boolean
     ) {
         try {
             val poEditorApiController = PoEditorApiControllerImpl(apiToken, moshi, poEditorApi)
@@ -152,7 +153,8 @@ object PoEditorStringsImporter {
                     originalStringsXmlDocument,
                     listOf(TABLET_REGEX_STRING),
                     unescapeHtmlTags,
-                    untranslatableStringsRegex?.toRegex()
+                    untranslatableStringsRegex?.toRegex(),
+                    includeComments
                 )
 
                 StringsXmlWriter.saveXml(

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/tasks/ImportPoEditorStringsTask.kt
@@ -160,6 +160,15 @@ abstract class ImportPoEditorStringsTask @Inject constructor() : DefaultTask() {
     abstract val untranslatableStringsRegex: Property<String?>
 
     /**
+     * Whether to include comments from the downloaded strings.
+     *
+     * Defaults to true.
+     */
+    @get:Optional
+    @get:Input
+    abstract val includeComments: Property<Boolean>
+
+    /**
      * Main task entrypoint.
      */
     @TaskAction
@@ -182,19 +191,26 @@ abstract class ImportPoEditorStringsTask @Inject constructor() : DefaultTask() {
         }
 
         PoEditorStringsImporter.importPoEditorStrings(
-            apiToken,
-            projectId,
-            defaultLang.getOrElse(DefaultValues.DEFAULT_LANG),
-            defaultResPath.getOrElse(getResourceDirectory(project, DefaultValues.MAIN_CONFIG_NAME).absolutePath),
-            filters.getOrElse(DefaultValues.FILTERS).map { FilterType.from(it) },
-            OrderType.from(order.getOrElse(DefaultValues.ORDER_TYPE.lowercase())),
-            tags.getOrElse(DefaultValues.TAGS),
-            languageValuesOverridePathMap.getOrElse(DefaultValues.LANGUAGE_VALUES_OVERRIDE_PATH_MAP),
-            minimumTranslationPercentage.getOrElse(DefaultValues.MINIMUM_TRANSLATION_PERCENTAGE),
-            resFileName.getOrElse(DefaultValues.RES_FILE_NAME),
-            unquoted.getOrElse(DefaultValues.UNQUOTED),
-            unescapeHtmlTags.getOrElse(DefaultValues.UNESCAPE_HTML_TAGS),
-            untranslatableStringsRegex.orNull
+            apiToken = apiToken,
+            projectId = projectId,
+            defaultLang = defaultLang.getOrElse(DefaultValues.DEFAULT_LANG),
+            resDirPath = defaultResPath.getOrElse(getResourceDirectory(
+                project, DefaultValues.MAIN_CONFIG_NAME).absolutePath
+            ),
+            filters = filters.getOrElse(DefaultValues.FILTERS).map { FilterType.from(it) },
+            order = OrderType.from(order.getOrElse(DefaultValues.ORDER_TYPE.lowercase())),
+            tags = tags.getOrElse(DefaultValues.TAGS),
+            languageValuesOverridePathMap = languageValuesOverridePathMap.getOrElse(
+                DefaultValues.LANGUAGE_VALUES_OVERRIDE_PATH_MAP
+            ),
+            minimumTranslationPercentage = minimumTranslationPercentage.getOrElse(
+                DefaultValues.MINIMUM_TRANSLATION_PERCENTAGE
+            ),
+            resFileName = resFileName.getOrElse(DefaultValues.RES_FILE_NAME),
+            unquoted = unquoted.getOrElse(DefaultValues.UNQUOTED),
+            unescapeHtmlTags = unescapeHtmlTags.getOrElse(DefaultValues.UNESCAPE_HTML_TAGS),
+            untranslatableStringsRegex = untranslatableStringsRegex.orNull,
+            includeComments = includeComments.getOrElse(DefaultValues.INCLUDE_COMMENTS)
         )
     }
 
@@ -211,5 +227,7 @@ abstract class ImportPoEditorStringsTask @Inject constructor() : DefaultTask() {
         this.minimumTranslationPercentage = extension.minimumTranslationPercentage
         this.unquoted = extension.unquoted
         this.unescapeHtmlTags = extension.unescapeHtmlTags
+        this.untranslatableStringsRegex = extension.untranslatableStringsRegex
+        this.includeComments = extension.includeComments
     }
 }

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/StringsXmlPostProcessor.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/StringsXmlPostProcessor.kt
@@ -44,10 +44,16 @@ object StringsXmlPostProcessor {
         translationStringsXmlDocument: StringsXmlDocument,
         fileSplitRegexStringList: List<String>,
         unescapeHtmlTags: Boolean,
-        untranslatableStringsRegex: Regex?
+        untranslatableStringsRegex: Regex?,
+        includeComments: Boolean
     ): Map<String, StringsXmlDocument> {
         val formattedStringsXmlDocument =
-            formatTranslationXml(translationStringsXmlDocument, unescapeHtmlTags, untranslatableStringsRegex)
+            formatTranslationXml(
+                translationStringsXmlDocument,
+                unescapeHtmlTags,
+                untranslatableStringsRegex,
+                includeComments
+            )
 
         val splitStringsXmlDocuments = splitTranslationXml(
             formattedStringsXmlDocument,
@@ -63,10 +69,18 @@ object StringsXmlPostProcessor {
     fun formatTranslationXml(
         translationStringsXmlDocument: StringsXmlDocument,
         unescapeHtmlTags: Boolean,
-        untranslatableStringsRegex: Regex?
+        untranslatableStringsRegex: Regex?,
+        includeComments: Boolean
     ): StringsXmlDocument {
         return translationStringsXmlDocument.map { resource ->
-            formatResource(resource, unescapeHtmlTags, untranslatableStringsRegex)
+            formatResource(resource, unescapeHtmlTags, untranslatableStringsRegex).let {
+                // Remove comments if the user specifies that they should not be included
+                if (!includeComments) {
+                    it.removeComment()
+                } else {
+                    it
+                }
+            }
         }
     }
 

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/models/StringsXmlDocument.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/xml/models/StringsXmlDocument.kt
@@ -252,4 +252,27 @@ sealed class StringsXmlResource(open val name: String, open val comments: List<S
             )
         }
     }
+
+    /**
+     * Removes the comments from the resource, returning a new resource without comments.
+     */
+    fun removeComment() = when (this) {
+        is StringElement -> {
+            this.copy(
+                comments = emptyList()
+            )
+        }
+
+        is PluralsElement -> {
+            this.copy(
+                comments = emptyList()
+            )
+        }
+
+        is StringArrayElement -> {
+            this.copy(
+                comments = emptyList()
+            )
+        }
+    }
 }

--- a/src/test/kotlin/com/hyperdevs/poeditor/gradle/xml/StringsXmlPostProcessorTest.kt
+++ b/src/test/kotlin/com/hyperdevs/poeditor/gradle/xml/StringsXmlPostProcessorTest.kt
@@ -212,7 +212,7 @@ class StringsXmlPostProcessorTest {
             )
         )
 
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null))
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, true))
     }
 
     @Test
@@ -234,7 +234,7 @@ class StringsXmlPostProcessorTest {
             )
         )
 
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null))
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, true))
     }
 
     @Test
@@ -252,7 +252,7 @@ class StringsXmlPostProcessorTest {
             )
         )
 
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null))
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, true))
     }
 
     @Test
@@ -270,7 +270,7 @@ class StringsXmlPostProcessorTest {
             )
         )
 
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null))
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, true))
     }
 
     @Test
@@ -316,7 +316,7 @@ class StringsXmlPostProcessorTest {
             )
         )
 
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null))
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, true))
     }
 
     @Test
@@ -410,7 +410,7 @@ class StringsXmlPostProcessorTest {
             )
         )
 
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null))
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, true))
     }
 
     @Test
@@ -428,7 +428,7 @@ class StringsXmlPostProcessorTest {
             )
         )
 
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null))
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, true))
     }
 
     @Test
@@ -446,7 +446,7 @@ class StringsXmlPostProcessorTest {
             )
         )
 
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null))
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, true))
     }
 
     @Test
@@ -464,7 +464,7 @@ class StringsXmlPostProcessorTest {
             )
         )
 
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, false, null))
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, false, null, true))
     }
 
     @Test
@@ -482,7 +482,7 @@ class StringsXmlPostProcessorTest {
             )
         )
 
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, false, null))
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, false, null, true))
     }
 
     @Test
@@ -500,7 +500,7 @@ class StringsXmlPostProcessorTest {
             )
         )
 
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null))
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, true))
     }
 
     @Test
@@ -530,7 +530,7 @@ class StringsXmlPostProcessorTest {
             )
         )
 
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null))
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, true))
     }
 
     @Test
@@ -643,8 +643,53 @@ class StringsXmlPostProcessorTest {
             StringsXmlPostProcessor.formatTranslationXml(
                 inputStringsXmlDocument,
                 true,
-                Regex("""^untranslatable(.+)$""")
+                Regex("""^untranslatable(.+)$"""),
+                true
             )
         )
+    }
+
+    @Test
+    fun `Postprocessing with including comments works`() {
+        // Test complete Xml
+        val inputStringsXmlDocument = StringsXmlDocument(
+            resources = listOf(
+                StringsXmlResource.StringElement("general_link_showAll", "Ver todo {{name}}", comments = listOf("Comment 1")),
+                StringsXmlResource.StringElement("general_button_goTop", "Ir arriba", comments = listOf("Comment 2")),
+                StringsXmlResource.StringElement("general_button_goBottom", "Ir${'\n'}abajo", comments = listOf("Comment 3"))
+            )
+        )
+
+        val expectedResult = StringsXmlDocument(
+            resources = listOf(
+                StringsXmlResource.StringElement("general_link_showAll", "Ver todo %1\$s", comments = listOf("Comment 1")),
+                StringsXmlResource.StringElement("general_button_goTop", "Ir arriba", comments = listOf("Comment 2")),
+                StringsXmlResource.StringElement("general_button_goBottom", "Ir${'\n'}abajo", comments = listOf("Comment 3"))
+            )
+        )
+
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, true))
+    }
+
+    @Test
+    fun `Postprocessing without including comments works`() {
+        // Test complete Xml
+        val inputStringsXmlDocument = StringsXmlDocument(
+            resources = listOf(
+                StringsXmlResource.StringElement("general_link_showAll", "Ver todo {{name}}", comments = listOf("Comment 1")),
+                StringsXmlResource.StringElement("general_button_goTop", "Ir arriba", comments = listOf("Comment 2")),
+                StringsXmlResource.StringElement("general_button_goBottom", "Ir${'\n'}abajo", comments = listOf("Comment 3"))
+            )
+        )
+
+        val expectedResult = StringsXmlDocument(
+            resources = listOf(
+                StringsXmlResource.StringElement("general_link_showAll", "Ver todo %1\$s"),
+                StringsXmlResource.StringElement("general_button_goTop", "Ir arriba"),
+                StringsXmlResource.StringElement("general_button_goBottom", "Ir${'\n'}abajo")
+            )
+        )
+
+        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, false))
     }
 }


### PR DESCRIPTION
### Github issue (delete if this does not apply)
Resolves #73 

### PR's key points
This pull request introduces a new feature to include comments from PoEditor in the generated XML files.
The usage is quite simple:

<details open><summary>Groovy</summary>

```groovy
poEditor {
    apiToken = "your_api_token"
    projectId = 12345
    defaultLang = "en"
    includeComments = true
}
```

</details>

<details><summary>Kotlin</summary>

```kotlin
poEditor {
    apiToken = "your_api_token"
    projectId = 12345
    defaultLang = "en"
    includeComments = true
}
```

</details>
 
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [x] Documentation added to README.md (if a new feature is added)
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
