### PR TITLE
Fix issues with parsing ampersands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ poEditor {
 ```
 
 </details>
+
 ### Changed
 - Refactor the whole parsing logic to better handle input and improve performance.
 ### Deprecated
@@ -55,7 +56,7 @@ poEditor {
 ### Removed
 - No removed features!
 ### Fixed
-- No fixed issues!
+- Fix bug with `&` character not being properly escaped.
 ### Security
 - No security issues fixed!
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Attribute                              | Description
 ```resFileName```                      | (Since 3.1.0) (Optional) Sets the file name for the imported string resource XML files. Defaults to `strings`.
 ```order```                            | (Since 3.1.0) (Optional) Defines how to order the export. Accepted values are defined by the POEditor API.
 ```unquoted```                         | (Since 3.2.0) (Optional) Defines if the strings should be unquoted, overriding default PoEditor configuration. Defaults to `false`.
-```unescapeHtmlTags```                 | (Since 3.4.0) (Optional) Whether or not to unescape HTML entitites from strings. Defaults to `true`.
+```unescapeHtmlTags```                 | (Since 3.4.0) (Optional) Whether or not to unescape HTML tags (`<`, `>`) from strings. Defaults to `true`.
 ```untranslatableStringsRegex```       | (Since 4.2.0) (Optional) Pattern to use to mark strings as translatable=false in the strings file. Defaults to `null`.
 ```includeComments```                  | (Since 5.0.0) (Optional) Whether to include comments from the downloaded strings. Defaults to `true`.
 

--- a/src/main/kotlin/com/hyperdevs/poeditor/gradle/extensions/StringExtensions.kt
+++ b/src/main/kotlin/com/hyperdevs/poeditor/gradle/extensions/StringExtensions.kt
@@ -26,9 +26,6 @@ private val cdataRegex = Regex("^<!\\[CDATA\\[(.*)]]>$", RegexOption.DOT_MATCHES
 fun String.unescapeHtmlTags() = this
     .replace("&lt;", "<")
     .replace("&gt;", ">")
-    .replace("&amp;", "&")
-    .replace("&apos;", "'")
-    .replace("&quot;", "\"")
 
 /**
  * Returns if the given string is a CDATA string.

--- a/src/test/kotlin/com/hyperdevs/poeditor/gradle/xml/StringsXmlPostProcessorTest.kt
+++ b/src/test/kotlin/com/hyperdevs/poeditor/gradle/xml/StringsXmlPostProcessorTest.kt
@@ -432,24 +432,6 @@ class StringsXmlPostProcessorTest {
     }
 
     @Test
-    fun `Postprocessing XML with string HTML symbols works 2`() {
-        // Test complete Xml
-        val inputStringsXmlDocument = StringsXmlDocument(
-            resources = listOf(
-                StringsXmlResource.StringElement("hello_friend_bold", "&amp;lt;b&amp;gt;Hello world&amp;lt;/b&amp;gt;")
-            )
-        )
-
-        val expectedResult = StringsXmlDocument(
-            resources = listOf(
-                StringsXmlResource.StringElement("hello_friend_bold", "&lt;b&gt;Hello world&lt;/b&gt;")
-            )
-        )
-
-        assertEquals(expectedResult, StringsXmlPostProcessor.formatTranslationXml(inputStringsXmlDocument, true, null, true))
-    }
-
-    @Test
     fun `Postprocessing XML with string HTML symbols and unescape set to false works`() {
         // Test complete Xml
         val inputStringsXmlDocument = StringsXmlDocument(


### PR DESCRIPTION
### Github issue (delete if this does not apply)
Resolves #66 

### PR's key points
The PR resolves the issue in #66 by basically removing managing all HTML entities, and only handling the ones related to `>` and `<` when unescaping HTML tags.
 
### Definition of Done
- [x] Changes summary added to CHANGELOG.md
- [x] Documentation added to README.md (if a new feature is added)
- [x] Tests added (if new code is added)
- [x] There is no outcommented or debug code left
